### PR TITLE
Added installing build-base to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,13 @@
 ############################
 FROM golang:alpine AS builder
 
-# Build Delve - This is helpful if you want to do remote debugging by attaching to one of the docker containers remotely
-RUN go get github.com/go-delve/delve/cmd/dlv
-
 # Git is required for fetching the dependencies,
 # make is required for building.
-RUN apk update && apk add --no-cache git make
+# build-base is needed because gcc is required by delve
+RUN apk update && apk add --no-cache git make build-base
+
+# Build Delve - This is helpful if you want to do remote debugging by attaching to one of the docker containers remotely
+RUN go get github.com/go-delve/delve/cmd/dlv
 
 WORKDIR /go/src/dc-ledger
 COPY . .


### PR DESCRIPTION
- Added installing build-base to Dockerfile because delve requires gcc.