### PR TITLE
Add unit tests for model version provisional

### DIFF
--- a/integration_tests/constants/constants.go
+++ b/integration_tests/constants/constants.go
@@ -86,6 +86,7 @@ var (
 	Owner                                             = Address1
 
 	// Compliance.
+	ProvisionalDate   = "2019-12-12T00:00:00Z"
 	CertificationDate = "2020-01-01T00:00:00Z"
 	RevocationDate    = "2020-03-03T03:30:00Z"
 	Reason            = "Some Reason"


### PR DESCRIPTION
- Added unit tests for model version provisional.
- Added missed check of testing results presence on certificating of provisioned model version.
- Corrected comments in CertifyModel and RevokeModel methods.