### PR TITLE
#183: State proofs in CLI and Light client proxy support

### DIFF
--- a/README-DEV.md
+++ b/README-DEV.md
@@ -163,18 +163,11 @@ Please take into account the following when sending a PR:
     So, make sure that `runtime.AssumeColonVerbOpt(true)` in `/x/pki/types/query.pb.gw.go`. 
     It's usually sufficient to revert the generated changes in `/x/pki/types/query.pb.gw.go`.
 - Call `validator.Validate(msg)` in `ValidateBasic` methods for all generated messages
+- Implement business logic in `msg_server_xxx.go`
 - Improve `NotFound` error processing:
     - replace `status.Error(codes.InvalidArgument, "not found")` to `status.Error(codes.NotFound, "not found")` in every generated `grpc_query_xxx.go` to return 404 error in REST.
-    - Add the following to every `cli/query_xxx.go` to not throw an error and help for not found entities in CLI
-    ``` 
-     if cli.IsNotFound(err) {
-         return clientCtx.PrintString(cli.NotFoundOutput)
-     }
-     if err != nil {
-         return err
-     }
-    ```
-- Implement business logic in `msg_server_xxx.go`
+- Support state proof for single value queries in CLI:
+    - use `cli.QueryWithProof` instead of cosmos queries that doesn't support state proofs
 - Add unit tests (see other modules for reference)
 - Add CLI-based integration tests to `integration_tests/cli/<module>` (see other modules for reference)
 - Add gRPC/REST-based integration tests to `integration_tests/grpc_rest/<module>` (see other modules for reference)

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -150,7 +150,7 @@ Please take into account the following when sending a PR:
 - Have a look at the scripts and commands used for generation of existing modules and do it in a similar way
   (for example [PKI module commands](scripts/starport/upgrade-0.44/07.pki_types.sh)).
 - Adjust the generated code
-  - correct REST endpoint: `/dcl` instead of `/zigbee-alliance/distributedcomplianceledger` in `proto/<module>/query.proto`
+  - correct REST endpoints: `/dcl` instead of `/zigbee-alliance/distributedcomplianceledger` in `proto/<module>/query.proto`
   - add message validation as annotations (`validate` tags) in `proto/<module>/tx.proto`
   - add `(cosmos_proto.scalar) = "cosmos.AddressString"` annotation for all fields with address/account type (such as `signer` or `owner`).
   - fix types if needed in `proto/<module>/<entity>.proto` files
@@ -168,6 +168,8 @@ Please take into account the following when sending a PR:
     - replace `status.Error(codes.InvalidArgument, "not found")` to `status.Error(codes.NotFound, "not found")` in every generated `grpc_query_xxx.go` to return 404 error in REST.
 - Support state proof for single value queries in CLI:
     - use `cli.QueryWithProof` instead of cosmos queries that doesn't support state proofs
+    - add proper handling for list queries and write requests when used with a light client proxy 
+      (see `IsWriteInsteadReadRpcError` and `IsKeyNotFoundRpcError`)
 - Add unit tests (see other modules for reference)
 - Add CLI-based integration tests to `integration_tests/cli/<module>` (see other modules for reference)
 - Add gRPC/REST-based integration tests to `integration_tests/grpc_rest/<module>` (see other modules for reference)

--- a/cmd/dcld/cmd/light.go
+++ b/cmd/dcld/cmd/light.go
@@ -1,0 +1,245 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	"github.com/spf13/cobra"
+	dbm "github.com/tendermint/tm-db"
+
+	tmcfg "github.com/tendermint/tendermint/config"
+	"github.com/tendermint/tendermint/libs/log"
+	tmmath "github.com/tendermint/tendermint/libs/math"
+	"github.com/tendermint/tendermint/light"
+	lproxy "github.com/tendermint/tendermint/light/proxy"
+	lrpc "github.com/tendermint/tendermint/light/rpc"
+	dbs "github.com/tendermint/tendermint/light/store/db"
+	rpcserver "github.com/tendermint/tendermint/rpc/jsonrpc/server"
+)
+
+// mostly copied from https://github.com/tendermint/tendermint/blob/master/cmd/tendermint/commands/light.go
+
+// LightCmd represents the base command when called without any subcommands
+var LightCmd = &cobra.Command{
+	Use:   "light [chainID]",
+	Short: "Run a light client proxy server, verifying Tendermint rpc",
+	Long: `Run a light client proxy server, verifying Tendermint rpc.
+
+All calls that can be tracked back to a block header by a proof
+will be verified before passing them back to the caller. Other than
+that, it will present the same interface as a full Tendermint node.
+
+Furthermore to the chainID, a fresh instance of a light client will
+need a primary RPC address, a trusted hash and height and witness RPC addresses
+(if not using sequential verification). To restart the node, thereafter
+only the chainID is required.
+
+When /abci_query is called, the Merkle key path format is:
+
+	/{store name}/{key}
+
+Please verify with your application that this Merkle key format is used (true
+for applications built w/ Cosmos SDK).
+`,
+	RunE: runProxy,
+	Args: cobra.ExactArgs(1),
+	Example: `light cosmoshub-3 -p http://52.57.29.196:26657 -w http://public-seed-node.cosmoshub.certus.one:26657
+	--height 962118 --hash 28B97BE9F6DE51AC69F70E0B7BFD7E5C9CD1A595B7DC31AFF27C50D4948020CD`,
+}
+
+var (
+	listenAddr         string
+	primaryAddr        string
+	witnessAddrsJoined string
+	chainID            string
+	dir                string
+	maxOpenConnections int
+
+	sequential     bool
+	trustingPeriod time.Duration
+	trustedHeight  int64
+	trustedHash    []byte
+	trustLevelStr  string
+
+	logLevel string
+	// logFormat string
+
+	primaryKey   = []byte("primary")
+	witnessesKey = []byte("witnesses")
+)
+
+func init() {
+	LightCmd.Flags().StringVar(&listenAddr, "laddr", "tcp://localhost:8888",
+		"serve the proxy on the given address")
+	LightCmd.Flags().StringVarP(&primaryAddr, "primary", "p", "",
+		"connect to a Tendermint node at this address")
+	LightCmd.Flags().StringVarP(&witnessAddrsJoined, "witnesses", "w", "",
+		"tendermint nodes to cross-check the primary node, comma-separated")
+	LightCmd.Flags().StringVarP(&dir, "dir", "d", os.ExpandEnv(filepath.Join("$HOME", ".tendermint-light")),
+		"specify the directory")
+	LightCmd.Flags().IntVar(
+		&maxOpenConnections,
+		"max-open-connections",
+		900,
+		"maximum number of simultaneous connections (including WebSocket).")
+	LightCmd.Flags().DurationVar(&trustingPeriod, "trusting-period", 168*time.Hour,
+		"trusting period that headers can be verified within. Should be significantly less than the unbonding period")
+	LightCmd.Flags().Int64Var(&trustedHeight, "height", 1, "Trusted header's height")
+	LightCmd.Flags().BytesHexVar(&trustedHash, "hash", []byte{}, "Trusted header's hash")
+	LightCmd.Flags().StringVar(&logLevel, "log-level", "info", "The logging level (debug|info|warn|error|fatal)")
+	// LightCmd.Flags().StringVar(&logFormat, "log-format", log.LogFormatPlain, "The logging format (text|json)")
+	LightCmd.Flags().StringVar(&trustLevelStr, "trust-level", "1/3",
+		"trust level. Must be between 1/3 and 3/3",
+	)
+	LightCmd.Flags().BoolVar(&sequential, "sequential", false,
+		"sequential verification. Verify all headers sequentially as opposed to using skipping verification",
+	)
+}
+
+func runProxy(cmd *cobra.Command, args []string) error {
+	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
+	var option log.Option
+	if logLevel == "info" {
+		option, _ = log.AllowLevel("info")
+	} else {
+		option, _ = log.AllowLevel("debug")
+	}
+	logger = log.NewFilter(logger, option)
+
+	chainID = args[0]
+	logger.Info("Creating client...", "chainID", chainID)
+
+	witnessesAddrs := []string{}
+	if witnessAddrsJoined != "" {
+		witnessesAddrs = strings.Split(witnessAddrsJoined, ",")
+	}
+
+	lightDB, err := dbm.NewGoLevelDB("light-client-db", dir)
+	if err != nil {
+		return fmt.Errorf("can't create a db: %w", err)
+	}
+	// create a prefixed db on the chainID
+	db := dbm.NewPrefixDB(lightDB, []byte(chainID))
+
+	if primaryAddr == "" { // check to see if we can start from an existing state
+		var err error
+		primaryAddr, witnessesAddrs, err = checkForExistingProviders(db)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve primary or witness from db: %w", err)
+		}
+		if primaryAddr == "" {
+			return errors.New("no primary address was provided nor found. Please provide a primary (using -p)." +
+				" Run the command: tendermint light --help for more information")
+		}
+	} else {
+		err := saveProviders(db, primaryAddr, witnessAddrsJoined)
+		if err != nil {
+			logger.Error("Unable to save primary and or witness addresses", "err", err)
+		}
+	}
+
+	trustLevel, err := tmmath.ParseFraction(trustLevelStr)
+	if err != nil {
+		return fmt.Errorf("can't parse trust level: %w", err)
+	}
+
+	options := []light.Option{light.Logger(logger)}
+
+	if sequential {
+		options = append(options, light.SequentialVerification())
+	} else {
+		options = append(options, light.SkippingVerification(trustLevel))
+	}
+
+	// Initiate the light client. If the trusted store already has blocks in it, this
+	// will be used else we use the trusted options.
+	c, err := light.NewHTTPClient(
+		context.Background(),
+		chainID,
+		light.TrustOptions{
+			Period: trustingPeriod,
+			Height: trustedHeight,
+			Hash:   trustedHash,
+		},
+		primaryAddr,
+		witnessesAddrs,
+		dbs.New(db, chainID),
+		options...,
+	)
+	if err != nil {
+		return err
+	}
+
+	config := tmcfg.DefaultConfig()
+	cfg := rpcserver.DefaultConfig()
+	cfg.MaxBodyBytes = config.RPC.MaxBodyBytes
+	cfg.MaxHeaderBytes = config.RPC.MaxHeaderBytes
+	cfg.MaxOpenConnections = maxOpenConnections
+	// If necessary adjust global WriteTimeout to ensure it's greater than
+	// TimeoutBroadcastTxCommit.
+	// See https://github.com/tendermint/tendermint/issues/3435
+	if cfg.WriteTimeout <= config.RPC.TimeoutBroadcastTxCommit {
+		cfg.WriteTimeout = config.RPC.TimeoutBroadcastTxCommit + 10*time.Second
+	}
+	cfg.WriteTimeout = config.RPC.TimeoutBroadcastTxCommit + 20*time.Second
+	cfg.ReadTimeout = 20 * time.Second
+
+	p, err := lproxy.NewProxy(c, listenAddr, primaryAddr, cfg, logger, lrpc.KeyPathFn(lrpc.DefaultMerkleKeyPathFn()))
+	if err != nil {
+		return err
+	}
+
+	// IMPORTANT: add support for IAVL (cosmos) proofs (Tendermint is not aware of them by default)
+	p.Client.RegisterOpDecoder(storetypes.ProofOpIAVLCommitment, storetypes.CommitmentOpDecoder)
+	p.Client.RegisterOpDecoder(storetypes.ProofOpSimpleMerkleCommitment, storetypes.CommitmentOpDecoder)
+
+	ctx, cancel := signal.NotifyContext(cmd.Context(), syscall.SIGTERM)
+	defer cancel()
+
+	go func() {
+		<-ctx.Done()
+		p.Listener.Close()
+	}()
+
+	logger.Info("Starting proxy...", "laddr", listenAddr)
+	if err := p.ListenAndServe(); err != http.ErrServerClosed {
+		// Error starting or closing listener:
+		logger.Error("proxy ListenAndServe", "err", err)
+	}
+
+	return nil
+}
+
+func checkForExistingProviders(db dbm.DB) (string, []string, error) {
+	primaryBytes, err := db.Get(primaryKey)
+	if err != nil {
+		return "", []string{""}, err
+	}
+	witnessesBytes, err := db.Get(witnessesKey)
+	if err != nil {
+		return "", []string{""}, err
+	}
+	witnessesAddrs := strings.Split(string(witnessesBytes), ",")
+	return string(primaryBytes), witnessesAddrs, nil
+}
+
+func saveProviders(db dbm.DB, primaryAddr, witnessesAddrs string) error {
+	err := db.Set(primaryKey, []byte(primaryAddr))
+	if err != nil {
+		return fmt.Errorf("failed to save primary provider: %w", err)
+	}
+	err = db.Set(witnessesKey, []byte(witnessesAddrs))
+	if err != nil {
+		return fmt.Errorf("failed to save witness providers: %w", err)
+	}
+	return nil
+}

--- a/cmd/dcld/cmd/light.go
+++ b/cmd/dcld/cmd/light.go
@@ -28,7 +28,7 @@ import (
 
 // mostly copied from https://github.com/tendermint/tendermint/blob/master/cmd/tendermint/commands/light.go
 
-// LightCmd represents the base command when called without any subcommands
+// LightCmd represents the base command when called without any subcommands.
 var LightCmd = &cobra.Command{
 	Use:   "light [chainID]",
 	Short: "Run a light client proxy server, verifying Tendermint rpc",
@@ -71,7 +71,7 @@ var (
 	trustLevelStr  string
 
 	logLevel string
-	// logFormat string
+	// logFormat string.
 
 	primaryKey   = []byte("primary")
 	witnessesKey = []byte("witnesses")
@@ -211,7 +211,7 @@ func runProxy(cmd *cobra.Command, args []string) error {
 	}()
 
 	logger.Info("Starting proxy...", "laddr", listenAddr)
-	if err := p.ListenAndServe(); err != http.ErrServerClosed {
+	if err := p.ListenAndServe(); errors.Is(err, http.ErrServerClosed) {
 		// Error starting or closing listener:
 		logger.Error("proxy ListenAndServe", "err", err)
 	}

--- a/cmd/dcld/cmd/root.go
+++ b/cmd/dcld/cmd/root.go
@@ -212,6 +212,7 @@ func initRootCmd(
 	for _, cmd := range options.addSubCmds {
 		rootCmd.AddCommand(cmd)
 	}
+	rootCmd.AddCommand(LightCmd)
 }
 
 // queryCommand returns the sub-command to send queries to the app.

--- a/cmd/settings/settings.go
+++ b/cmd/settings/settings.go
@@ -24,6 +24,5 @@ const (
 	DefaultBroadcastMode = flags.BroadcastBlock
 )
 
-// PruningStrategy of the application: Store every state. Keep last two states.
-// FIXME issue 9 review the arguments and especially the 3rd one (a new one).
-var PruningStrategy = types.NewPruningOptions(2, 1, 1)
+// PruningStrategy of the application: Store every 100th state. Keep last 100 states. Do pruning at every 10th height.
+var PruningStrategy = types.NewPruningOptions(100, 100, 10)

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -63,7 +63,9 @@ In order to connect the CLI to a DC Ledger Network (Chain), the following parame
     * A list of Observer Node addresses for persistent networks (such as the Test Net)
     can be found in the corresponding subfolders within [Persistent Chains](../deployment/persistent_chains).
     * Please look at [Observer Nodes](../deployment/persistent_chains/testnet/nodes.md) for a list of Observer nodes for the current `testnet`.
-
+    * If you don't have any trusted nodes (Observers or Validators) for connection,
+      consider running a Light Client Proxy Server and connecting a CLI to it. 
+      See [Run Light Client Proxy](docs/run-light-client-proxy.md).
 
 ## Getting Account
 Ledger is public for read which means that anyone can read from the Ledger without a need to have 

--- a/docs/run-light-client-proxy.md
+++ b/docs/run-light-client-proxy.md
@@ -1,0 +1,58 @@
+# Run Light Client Proxy
+Light Client Proxy can be used if there are no trusted Full Nodes (Validator or Observers) a client can connect to.
+
+It can be a proxy for CLI or direct requests from code done via Tendermint RPC.
+
+Please note, that CLI can use a Light Client proxy only for single-value query requests.
+A Full Node (Validator or Observer) should be used for multi-value query requests and write requests.
+
+See the following links for details about a Light Client:
+- https://docs.tendermint.com/master/tendermint-core/light-client.html
+- https://docs.tendermint.com/master/nodes/light-client.html
+
+## Running Light Client Proxy
+See https://docs.tendermint.com/master/nodes/light-client.html for details
+
+### 1. Choose Semi-trusted or Non-trusted Nodes for Connection
+Light Client must be connected to one Primary Full Node (Validator or Observer) and
+a number of Witness Full Nodes (Validators or Observers).
+
+### 2. Obtain Trusted Height & Hash
+One way to obtain a semi-trusted hash & height is to query multiple full nodes and compare their hashes.
+
+For the first node (for example Primary Node):
+```bash
+curl -s http(s)://<node host>:26657/commit | jq "{height: .result.signed_header.header.height, hash: .result.signed_header.commit.block_id.hash}"
+```
+Result Example:
+```
+{
+  "height": "<height>",
+  "hash": "<hash>"
+}
+```
+
+For other nodes (for example Witness Nodes):
+```bash
+curl -s http(s)://<node host>:26657/commit?height=<height> | jq "{height: .result.signed_header.header.height, hash: .result.signed_header.commit.block_id.hash}"
+```
+Where `<height>` obtained from the first run.
+
+If result is the same on all nodes, then obtained `<height>` and `<hash>` can be used as parameters for the light client at the next step.
+
+### 3. Start a Light Client Proxy Server
+```
+dcld light <chain-id> -p tcp://<primary-host>:26657 -w tcp://<witness1-host>:26657,tcp://<witness2-host>:26657 --height <height> --hash <hash>
+```
+where `<height>` and `<hash>` obtained at the previous step.
+
+Light Client Proxy is started at port `8888` by default. It can be changed with `--laddr` argument.
+
+Light Client Proxy will write some information (about headers) to disk. Default location is `~/.tendermint-light`.
+It can be changed with `--dir` argument.
+
+### 4. Connect CLI to a Light Client Proxy Server
+```
+dcld config chain-id <chain-id>
+dcld config node tcp://<light-client-proxy-host>:8888
+```

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -34,7 +34,6 @@ an Account or sign the request.
        - Fetch `account number` and `sequence` by CLI 1:  `dcld query auth account --address <address>`
        - Sign transaction by CLI 2: `dcld tx sign txn.json --from <from> --account-number <int> --sequence <int> --gas "auto" --offline --output-document txn.json`
        - Broadcat transaction by CLI 1: `dcld tx broadcast txn.json`
-
 - gRPC:
     - Generate a client code from the proto files [proto](../proto) for the client language (see https://grpc.io/docs/languages/)   
     - Build, sign, and broadcast the message (transaction). 

--- a/go.mod
+++ b/go.mod
@@ -31,5 +31,6 @@ require (
 replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
+	github.com/tendermint/tendermint => github.com/zigbee-alliance/tendermint v0.34.140
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,4 @@
 4d63.com/gochecknoglobals v0.0.0-20201008074935-acfc0b28355a/go.mod h1:wfdC5ZjKSPr7CybKEcgJhUOgeAQW1+7WcyK8OvUilfo=
-bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
 bitbucket.org/creachadair/shell v0.0.6/go.mod h1:8Qqi/cYk7vPnsOePHroKXDJYmb5x7ENhtiFtfZq8K+M=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -187,14 +186,11 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/coinbase/rosetta-sdk-go v0.6.10 h1:rgHD/nHjxLh0lMEdfGDqpTtlvtSBwULqrrZ2qPdNaCM=
 github.com/coinbase/rosetta-sdk-go v0.6.10/go.mod h1:J/JFMsfcePrjJZkwQFLh+hJErkAmdm9Iyy3D5Y0LfXo=
-github.com/confio/ics23/go v0.0.0-20200817220745-f173e6211efb/go.mod h1:E45NqnlpxGnpfTWL/xauN7MRwEE28T4Dd4uraToOaKg=
-github.com/confio/ics23/go v0.6.3/go.mod h1:E45NqnlpxGnpfTWL/xauN7MRwEE28T4Dd4uraToOaKg=
 github.com/confio/ics23/go v0.6.6 h1:pkOy18YxxJ/r0XFDCnrl4Bjv6h4LkBSpLS6F38mrKL8=
 github.com/confio/ics23/go v0.6.6/go.mod h1:E45NqnlpxGnpfTWL/xauN7MRwEE28T4Dd4uraToOaKg=
 github.com/containerd/console v1.0.2/go.mod h1:ytZPjGgY2oeTkAONYafi2kSj0aYggsf8acV1PGKCbzQ=
+github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6 h1:NmTXa/uVnDyp0TY5MKi197+3HWcnYWfnHGyaFthlnGw=
 github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
-github.com/containerd/continuity v0.1.0 h1:UFRRY5JemiAhPZrr/uE0n8fMTLcZsUvySPr1+D7pgr8=
-github.com/containerd/continuity v0.1.0/go.mod h1:ICJu0PwR54nI0yPEnJ6jcS+J7CZAUXrLh8lPo2knzsM=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -218,9 +214,6 @@ github.com/cosmos/cosmos-sdk v0.44.5/go.mod h1:maUA6m2TBxOJZkbwl0eRtEBgTX37kcaiO
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
-github.com/cosmos/iavl v0.15.0-rc3.0.20201009144442-230e9bdf52cd/go.mod h1:3xOIaNNX19p0QrX0VqWa6voPRoJRGGYtny+DH8NEPvE=
-github.com/cosmos/iavl v0.15.0-rc5/go.mod h1:WqoPL9yPTQ85QBMT45OOUzPxG/U/JcJoN7uMjgxke/I=
-github.com/cosmos/iavl v0.15.3/go.mod h1:OLjQiAQ4fGD2KDZooyJG9yz+p2ao2IAYSbke8mVvSA4=
 github.com/cosmos/iavl v0.17.1/go.mod h1:7aisPZK8yCpQdy3PMvKeO+bhq1NwDjUwjzxwwROUxFk=
 github.com/cosmos/iavl v0.17.3 h1:s2N819a2olOmiauVa0WAhoIJq9EhSXE9HDBAoR9k+8Y=
 github.com/cosmos/iavl v0.17.3/go.mod h1:prJoErZFABYZGDHka1R6Oay4z9PrNeFFiMKHDAMOi4w=
@@ -250,7 +243,6 @@ github.com/decred/dcrd/lru v1.0.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0
 github.com/denis-tingajkin/go-header v0.4.2/go.mod h1:eLRHAVXzE5atsKAnNRDB90WHCFFnBUn4RN0nRcs1LJA=
 github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f h1:U5y3Y5UE0w7amNe7Z5G/twsBW0KEalRQXZzf8ufSh9I=
 github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f/go.mod h1:xH/i4TFMt8koVQZ6WFms69WAsDWr2XsYL3Hkl7jkoLE=
-github.com/dgraph-io/badger/v2 v2.2007.1/go.mod h1:26P/7fbL4kUZVEVKLAKXkBXKOydDmM2p1e+NhhnBCAE=
 github.com/dgraph-io/badger/v2 v2.2007.2 h1:EjjK0KqwaFMlPin1ajhP943VPENHJdEz1KLIegjaI3k=
 github.com/dgraph-io/badger/v2 v2.2007.2/go.mod h1:26P/7fbL4kUZVEVKLAKXkBXKOydDmM2p1e+NhhnBCAE=
 github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
@@ -486,7 +478,6 @@ github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1-0.20190629185528-ae1634f6a989/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
@@ -504,7 +495,6 @@ github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277/go.mod h1
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
-github.com/grpc-ecosystem/go-grpc-middleware v1.2.1/go.mod h1:EaizFBKfUKtMIF5iaDEhniwNedqGo9FuLFzppDr3uwI=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.2/go.mod h1:EaizFBKfUKtMIF5iaDEhniwNedqGo9FuLFzppDr3uwI=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
@@ -513,7 +503,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.8.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.12.1/go.mod h1:8XEsbTttt/W+VvjtQhLACqCisSPWTxCZ7sBRjU6iH9c=
-github.com/grpc-ecosystem/grpc-gateway v1.14.7/go.mod h1:oYZKL012gGh6LMyg/xA7Q2yq6j8bu0wa+9w14EEthWU=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
@@ -778,9 +767,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.13.0 h1:7lLHu94wT9Ij0o6EWWclhu0aOh32VxhkwEJvzuWPeak=
 github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
+github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
-github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
-github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
@@ -915,7 +903,6 @@ github.com/ryanrolds/sqlclosecheck v0.3.0/go.mod h1:1gREqxyTGR3lVtpngyFo3hZAgk0K
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/sanposhiho/wastedassign/v2 v2.0.6/go.mod h1:KyZ0MWTwxxBmfwn33zh3k1dmsbF2ud9pAAGfoLfjhtI=
-github.com/sasha-s/go-deadlock v0.2.0/go.mod h1:StQn567HiB1fF2yJ44N9au7wOhrPS3iZqiDbRupzT10=
 github.com/sasha-s/go-deadlock v0.2.1-0.20190427202633-1595213edefa h1:0U2s5loxrTy6/VgfVoLuVLFJcURKLH49ie0zSch7gh4=
 github.com/sasha-s/go-deadlock v0.2.1-0.20190427202633-1595213edefa/go.mod h1:F73l+cr82YSh10GxyRI6qZiCgK64VaZjwesgfQ1/iLM=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
@@ -956,7 +943,6 @@ github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
-github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
 github.com/spf13/cobra v1.2.1 h1:+KmjbUw1hriSNMF55oPrkZcb27aECyrj8V2ytv7kWDw=
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
@@ -968,7 +954,6 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
-github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.8.1 h1:Kq1fyeebqsBfbjZj4EL7gj2IO0mMaiyjYUWcUsl2O44=
@@ -1009,14 +994,6 @@ github.com/tendermint/go-amino v0.16.0 h1:GyhmgQKvqF82e2oZeuMSp9JTN0N09emoSZlb2l
 github.com/tendermint/go-amino v0.16.0/go.mod h1:TQU0M1i/ImAo+tYpZi73AU3V/dKeCoMC9Sphe2ZwGME=
 github.com/tendermint/spm v0.1.9 h1:O1DJF4evS8wgk5SZqRcO29irNNtKQmTpvQ0xFzUiczI=
 github.com/tendermint/spm v0.1.9/go.mod h1:iHgfQ5YOI6ONc9E7ugGQolVdfSMHpeXfZ/OpXuN/42Q=
-github.com/tendermint/tendermint v0.34.0-rc4/go.mod h1:yotsojf2C1QBOw4dZrTcxbyxmPUrT4hNuOQWX9XUwB4=
-github.com/tendermint/tendermint v0.34.0-rc6/go.mod h1:ugzyZO5foutZImv0Iyx/gOFCX6mjJTgbLHTwi17VDVg=
-github.com/tendermint/tendermint v0.34.0/go.mod h1:Aj3PIipBFSNO21r+Lq3TtzQ+uKESxkbA3yo/INM4QwQ=
-github.com/tendermint/tendermint v0.34.13/go.mod h1:6RVVRBqwtKhA+H59APKumO+B7Nye4QXSFc6+TYxAxCI=
-github.com/tendermint/tendermint v0.34.14 h1:GCXmlS8Bqd2Ix3TQCpwYLUNHe+Y+QyJsm5YE+S/FkPo=
-github.com/tendermint/tendermint v0.34.14/go.mod h1:FrwVm3TvsVicI9Z7FlucHV6Znfd5KBc/Lpp69cCwtk0=
-github.com/tendermint/tm-db v0.6.2/go.mod h1:GYtQ67SUvATOcoY8/+x6ylk8Qo02BQyLrAs+yAcLvGI=
-github.com/tendermint/tm-db v0.6.3/go.mod h1:lfA1dL9/Y/Y8wwyPp2NMLyn5P5Ptr/gvDFNWtrCWSf8=
 github.com/tendermint/tm-db v0.6.4 h1:3N2jlnYQkXNQclQwd/eKV/NzlqPlfK21cpRRIx80XXQ=
 github.com/tendermint/tm-db v0.6.4/go.mod h1:dptYhIpJ2M5kUuenLr+Yyf3zQOv1SgBZcl8/BmWlMBw=
 github.com/tetafro/godot v1.4.9/go.mod h1:LR3CJpxDVGlYOWn3ZZg1PgNZdTUvzsZWu8xaEohUpn8=
@@ -1036,7 +1013,6 @@ github.com/tommy-muehle/go-mnd/v2 v2.4.0/go.mod h1:WsUAkMJMYww6l/ufffCD3m+P7LEvr
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
 github.com/tyler-smith/go-bip39 v1.0.2/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
-github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
@@ -1070,6 +1046,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+github.com/zigbee-alliance/tendermint v0.34.140 h1:QqY9+zNDZNtYGte62UnrBWuJNsu0zSizqA3FY4E2Jp4=
+github.com/zigbee-alliance/tendermint v0.34.140/go.mod h1:FrwVm3TvsVicI9Z7FlucHV6Znfd5KBc/Lpp69cCwtk0=
 github.com/zondax/hid v0.9.0 h1:eiT3P6vNxAEVxXMw66eZUAAnU2zD33JBkfG/EnfAKl8=
 github.com/zondax/hid v0.9.0/go.mod h1:l5wttcP0jwtdLjqjMMWFVEE7d1zO0jvSPA9OPZxWpEM=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -1124,7 +1102,6 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
@@ -1184,7 +1161,6 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -1525,7 +1501,6 @@ google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20201111145450-ac7456db90a6/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201119123407-9b1e624d6bc4/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201201144952-b05cb90ed32e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201210142538-e3217bee35cc/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=

--- a/utils/cli/utils.go
+++ b/utils/cli/utils.go
@@ -33,6 +33,19 @@ func QueryWithProof(clientCtx client.Context, storeName string, keyPrefix string
 	return clientCtx.PrintProto(res)
 }
 
+func QueryWithProofList(clientCtx client.Context, storeName string, keyPrefix string, key []byte, res codec.ProtoMarshaler) error {
+	key = append([]byte(keyPrefix), key...)
+	resBytes, _, err := clientCtx.QueryStore(key, storeName)
+	if err != nil {
+		return err
+	}
+	// return default (empty) list if not found
+	if resBytes != nil {
+		clientCtx.Codec.MustUnmarshal(resBytes, res)
+	}
+	return clientCtx.PrintProto(res)
+}
+
 func ReadFromFile(target string) (string, error) {
 	if _, err := os.Stat(target); err == nil { // check whether it is a path
 		bytes, err := ioutil.ReadFile(target)

--- a/utils/cli/utils.go
+++ b/utils/cli/utils.go
@@ -1,17 +1,21 @@
 package cli
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
+	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 const (
-	NotFoundOutput = "\"Not Found\""
+	NotFoundOutput            = "\"Not Found\"\n"
+	LightClientForListQueries = "\"List queries don't work with a Light Client Proxy. Please connect to a Full Node client you trust if you need to use list queries.\"\n"
 )
 
 func ReadFromFile(target string) (string, error) {
@@ -36,6 +40,16 @@ func IsNotFound(err error) bool {
 		return false
 	}
 	return s.Code() == codes.NotFound
+}
+func IsKeyNotFoundRpcError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var rpcerror *rpctypes.RPCError
+	if !errors.As(err, &rpcerror) {
+		return false
+	}
+	return strings.Contains(rpcerror.Message, "Internal error") && strings.Contains(rpcerror.Data, "empty key")
 }
 
 func AddTxFlagsToCmd(cmd *cobra.Command) {

--- a/x/compliance/client/cli/query_certified_model.go
+++ b/x/compliance/client/cli/query_certified_model.go
@@ -5,9 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"github.com/zigbee-alliance/distributed-compliance-ledger/utils/cli"
 	"github.com/zigbee-alliance/distributed-compliance-ledger/x/compliance/types"
 )
@@ -31,6 +29,9 @@ func CmdListCertifiedModel() *cobra.Command {
 			}
 
 			res, err := queryClient.CertifiedModelAll(context.Background(), params)
+			if cli.IsKeyNotFoundRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForListQueries)
+			}
 			if err != nil {
 				return err
 			}
@@ -46,6 +47,13 @@ func CmdListCertifiedModel() *cobra.Command {
 }
 
 func CmdShowCertifiedModel() *cobra.Command {
+	var (
+		vid               int32
+		pid               int32
+		softwareVersion   uint32
+		certificationType string
+	)
+
 	cmd := &cobra.Command{
 		Use: "certified-model",
 		Short: "Gets a boolean if the given Model (identified by the `vid`, `pid`, `softwareVersion` and " +
@@ -53,46 +61,21 @@ func CmdShowCertifiedModel() *cobra.Command {
 		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx := client.GetClientContextFromCmd(cmd)
-
-			queryClient := types.NewQueryClient(clientCtx)
-
-			argVid, err := cast.ToInt32E(viper.GetString(FlagVID))
-			if err != nil {
-				return err
-			}
-			argPid, err := cast.ToInt32E(viper.GetString(FlagPID))
-			if err != nil {
-				return err
-			}
-			argSoftwareVersion, err := cast.ToUint32E(viper.GetString(FlagSoftwareVersion))
-			if err != nil {
-				return err
-			}
-			argCertificationType := viper.GetString(FlagCertificationType)
-
-			params := &types.QueryGetCertifiedModelRequest{
-				Vid:               argVid,
-				Pid:               argPid,
-				SoftwareVersion:   argSoftwareVersion,
-				CertificationType: argCertificationType,
-			}
-
-			res, err := queryClient.CertifiedModel(context.Background(), params)
-			if cli.IsNotFound(err) {
-				return clientCtx.PrintString(cli.NotFoundOutput)
-			}
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(res)
+			var res types.CertifiedModel
+			return cli.QueryWithProof(
+				clientCtx,
+				types.StoreKey,
+				types.CertifiedModelKeyPrefix,
+				types.CertifiedModelKey(vid, pid, softwareVersion, certificationType),
+				&res,
+			)
 		},
 	}
 
-	cmd.Flags().String(FlagVID, "", "Model vendor ID")
-	cmd.Flags().String(FlagPID, "", "Model product ID")
-	cmd.Flags().String(FlagSoftwareVersion, "", "Model software version")
-	cmd.Flags().StringP(FlagCertificationType, FlagCertificationTypeShortcut, "", TextCertificationType)
+	cmd.Flags().Int32Var(&vid, FlagVID, 0, "Model vendor ID")
+	cmd.Flags().Int32Var(&pid, FlagPID, 0, "Model product ID")
+	cmd.Flags().Uint32Var(&softwareVersion, FlagSoftwareVersion, 0, "Model software version")
+	cmd.Flags().StringVarP(&certificationType, FlagCertificationType, FlagCertificationTypeShortcut, "", TextCertificationType)
 
 	_ = cmd.MarkFlagRequired(FlagVID)
 	_ = cmd.MarkFlagRequired(FlagPID)

--- a/x/compliance/client/cli/query_provisional_model.go
+++ b/x/compliance/client/cli/query_provisional_model.go
@@ -5,9 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"github.com/zigbee-alliance/distributed-compliance-ledger/utils/cli"
 	"github.com/zigbee-alliance/distributed-compliance-ledger/x/compliance/types"
 )
@@ -31,6 +29,9 @@ func CmdListProvisionalModel() *cobra.Command {
 			}
 
 			res, err := queryClient.ProvisionalModelAll(context.Background(), params)
+			if cli.IsKeyNotFoundRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForListQueries)
+			}
 			if err != nil {
 				return err
 			}
@@ -46,52 +47,34 @@ func CmdListProvisionalModel() *cobra.Command {
 }
 
 func CmdShowProvisionalModel() *cobra.Command {
+	var (
+		vid               int32
+		pid               int32
+		softwareVersion   uint32
+		certificationType string
+	)
+
 	cmd := &cobra.Command{
 		Use:   "provisional-model",
 		Short: "Gets a boolean if the given Model (identified by the `vid`, `pid`, `softwareVersion` and `certification_type`) is in provisional state",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx := client.GetClientContextFromCmd(cmd)
-
-			queryClient := types.NewQueryClient(clientCtx)
-
-			argVid, err := cast.ToInt32E(viper.GetString(FlagVID))
-			if err != nil {
-				return err
-			}
-			argPid, err := cast.ToInt32E(viper.GetString(FlagPID))
-			if err != nil {
-				return err
-			}
-			argSoftwareVersion, err := cast.ToUint32E(viper.GetString(FlagSoftwareVersion))
-			if err != nil {
-				return err
-			}
-			argCertificationType := viper.GetString(FlagCertificationType)
-
-			params := &types.QueryGetProvisionalModelRequest{
-				Vid:               argVid,
-				Pid:               argPid,
-				SoftwareVersion:   argSoftwareVersion,
-				CertificationType: argCertificationType,
-			}
-
-			res, err := queryClient.ProvisionalModel(context.Background(), params)
-			if cli.IsNotFound(err) {
-				return clientCtx.PrintString(cli.NotFoundOutput)
-			}
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(res)
+			var res types.ProvisionalModel
+			return cli.QueryWithProof(
+				clientCtx,
+				types.StoreKey,
+				types.ProvisionalModelKeyPrefix,
+				types.ProvisionalModelKey(vid, pid, softwareVersion, certificationType),
+				&res,
+			)
 		},
 	}
 
-	cmd.Flags().String(FlagVID, "", "Model vendor ID")
-	cmd.Flags().String(FlagPID, "", "Model product ID")
-	cmd.Flags().String(FlagSoftwareVersion, "", "Model software version")
-	cmd.Flags().StringP(FlagCertificationType, FlagCertificationTypeShortcut, "", TextCertificationType)
+	cmd.Flags().Int32Var(&vid, FlagVID, 0, "Model vendor ID")
+	cmd.Flags().Int32Var(&pid, FlagPID, 0, "Model product ID")
+	cmd.Flags().Uint32Var(&softwareVersion, FlagSoftwareVersion, 0, "Model software version")
+	cmd.Flags().StringVarP(&certificationType, FlagCertificationType, FlagCertificationTypeShortcut, "", TextCertificationType)
 
 	_ = cmd.MarkFlagRequired(FlagVID)
 	_ = cmd.MarkFlagRequired(FlagPID)

--- a/x/compliance/client/cli/query_revoked_model.go
+++ b/x/compliance/client/cli/query_revoked_model.go
@@ -5,9 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"github.com/zigbee-alliance/distributed-compliance-ledger/utils/cli"
 	"github.com/zigbee-alliance/distributed-compliance-ledger/x/compliance/types"
 )
@@ -31,6 +29,9 @@ func CmdListRevokedModel() *cobra.Command {
 			}
 
 			res, err := queryClient.RevokedModelAll(context.Background(), params)
+			if cli.IsKeyNotFoundRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForListQueries)
+			}
 			if err != nil {
 				return err
 			}
@@ -46,52 +47,34 @@ func CmdListRevokedModel() *cobra.Command {
 }
 
 func CmdShowRevokedModel() *cobra.Command {
+	var (
+		vid               int32
+		pid               int32
+		softwareVersion   uint32
+		certificationType string
+	)
+
 	cmd := &cobra.Command{
 		Use:   "revoked-model",
 		Short: "Gets a boolean if the given Model (identified by the `vid`, `pid`, `softwareVersion` and `certification_type`) is revoked",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx := client.GetClientContextFromCmd(cmd)
-
-			queryClient := types.NewQueryClient(clientCtx)
-
-			argVid, err := cast.ToInt32E(viper.GetString(FlagVID))
-			if err != nil {
-				return err
-			}
-			argPid, err := cast.ToInt32E(viper.GetString(FlagPID))
-			if err != nil {
-				return err
-			}
-			argSoftwareVersion, err := cast.ToUint32E(viper.GetString(FlagSoftwareVersion))
-			if err != nil {
-				return err
-			}
-			argCertificationType := viper.GetString(FlagCertificationType)
-
-			params := &types.QueryGetRevokedModelRequest{
-				Vid:               argVid,
-				Pid:               argPid,
-				SoftwareVersion:   argSoftwareVersion,
-				CertificationType: argCertificationType,
-			}
-
-			res, err := queryClient.RevokedModel(context.Background(), params)
-			if cli.IsNotFound(err) {
-				return clientCtx.PrintString(cli.NotFoundOutput)
-			}
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(res)
+			var res types.RevokedModel
+			return cli.QueryWithProof(
+				clientCtx,
+				types.StoreKey,
+				types.RevokedModelKeyPrefix,
+				types.RevokedModelKey(vid, pid, softwareVersion, certificationType),
+				&res,
+			)
 		},
 	}
 
-	cmd.Flags().String(FlagVID, "", "Model vendor ID")
-	cmd.Flags().String(FlagPID, "", "Model product ID")
-	cmd.Flags().String(FlagSoftwareVersion, "", "Model software version")
-	cmd.Flags().StringP(FlagCertificationType, FlagCertificationTypeShortcut, "", TextCertificationType)
+	cmd.Flags().Int32Var(&vid, FlagVID, 0, "Model vendor ID")
+	cmd.Flags().Int32Var(&pid, FlagPID, 0, "Model product ID")
+	cmd.Flags().Uint32Var(&softwareVersion, FlagSoftwareVersion, 0, "Model software version")
+	cmd.Flags().StringVarP(&certificationType, FlagCertificationType, FlagCertificationTypeShortcut, "", TextCertificationType)
 
 	_ = cmd.MarkFlagRequired(FlagVID)
 	_ = cmd.MarkFlagRequired(FlagPID)

--- a/x/compliance/client/cli/tx_certify_model.go
+++ b/x/compliance/client/cli/tx_certify_model.go
@@ -46,10 +46,13 @@ func CmdCertifyModel() *cobra.Command {
 				certificationType,
 				reason,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
+
+			// validate basic will be called in GenerateOrBroadcastTxCLI
+			err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			if cli.IsWriteInsteadReadRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForWriteRequests)
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return err
 		},
 	}
 	cmd.Flags().Int32Var(&vid, FlagVID, 0,

--- a/x/compliance/client/cli/tx_provision_model.go
+++ b/x/compliance/client/cli/tx_provision_model.go
@@ -46,10 +46,13 @@ func CmdProvisionModel() *cobra.Command {
 				certificationType,
 				reason,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
+
+			// validate basic will be called in GenerateOrBroadcastTxCLI
+			err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			if cli.IsWriteInsteadReadRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForWriteRequests)
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return err
 		},
 	}
 

--- a/x/compliance/client/cli/tx_revoke_model.go
+++ b/x/compliance/client/cli/tx_revoke_model.go
@@ -46,10 +46,13 @@ func CmdRevokeModel() *cobra.Command {
 				certificationType,
 				reason,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
+
+			// validate basic will be called in GenerateOrBroadcastTxCLI
+			err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			if cli.IsWriteInsteadReadRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForWriteRequests)
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return err
 		},
 	}
 	cmd.Flags().Int32Var(&vid, FlagVID, 0,

--- a/x/compliancetest/client/cli/tx_add_testing_result.go
+++ b/x/compliancetest/client/cli/tx_add_testing_result.go
@@ -55,11 +55,12 @@ func CmdAddTestingResult() *cobra.Command {
 				argTestDate,
 			)
 
-			if err := msg.ValidateBasic(); err != nil {
-				return err
+			// validate basic will be called in GenerateOrBroadcastTxCLI
+			err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			if cli.IsWriteInsteadReadRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForWriteRequests)
 			}
-
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return err
 		},
 	}
 

--- a/x/dclauth/client/cli/query_pending_account_revocation.go
+++ b/x/dclauth/client/cli/query_pending_account_revocation.go
@@ -31,6 +31,9 @@ func CmdListPendingAccountRevocation() *cobra.Command {
 			}
 
 			res, err := queryClient.PendingAccountRevocationAll(context.Background(), params)
+			if cli.IsKeyNotFoundRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForListQueries)
+			}
 			if err != nil {
 				return err
 			}
@@ -53,26 +56,19 @@ func CmdShowPendingAccountRevocation() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx := client.GetClientContextFromCmd(cmd)
 
-			queryClient := types.NewQueryClient(clientCtx)
-
 			argAddress, err := sdk.AccAddressFromBech32(viper.GetString(FlagAddress))
 			if err != nil {
 				return err
 			}
 
-			params := &types.QueryGetPendingAccountRevocationRequest{
-				Address: argAddress.String(),
-			}
-
-			res, err := queryClient.PendingAccountRevocation(context.Background(), params)
-			if cli.IsNotFound(err) {
-				return clientCtx.PrintString(cli.NotFoundOutput)
-			}
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(res)
+			var res types.PendingAccountRevocation
+			return cli.QueryWithProof(
+				clientCtx,
+				types.StoreKey,
+				types.PendingAccountRevocationKeyPrefix,
+				types.PendingAccountRevocationKey(argAddress),
+				&res,
+			)
 		},
 	}
 

--- a/x/dclauth/client/cli/tx_approve_add_account.go
+++ b/x/dclauth/client/cli/tx_approve_add_account.go
@@ -35,10 +35,13 @@ func CmdApproveAddAccount() *cobra.Command {
 				clientCtx.GetFromAddress(),
 				argAddress,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
+
+			// validate basic will be called in GenerateOrBroadcastTxCLI
+			err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			if cli.IsWriteInsteadReadRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForWriteRequests)
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return err
 		},
 	}
 

--- a/x/dclauth/client/cli/tx_approve_revoke_account.go
+++ b/x/dclauth/client/cli/tx_approve_revoke_account.go
@@ -35,10 +35,13 @@ func CmdApproveRevokeAccount() *cobra.Command {
 				clientCtx.GetFromAddress(),
 				argAddress,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
+
+			// validate basic will be called in GenerateOrBroadcastTxCLI
+			err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			if cli.IsWriteInsteadReadRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForWriteRequests)
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return err
 		},
 	}
 

--- a/x/dclauth/client/cli/tx_propose_add_account.go
+++ b/x/dclauth/client/cli/tx_propose_add_account.go
@@ -69,12 +69,12 @@ func CmdProposeAddAccount() *cobra.Command {
 				return err
 			}
 
-			/* it is done inside next step
-			if err := msg.ValidateBasic(); err != nil {
-				return err
+			// validate basic will be called in GenerateOrBroadcastTxCLI
+			err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			if cli.IsWriteInsteadReadRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForWriteRequests)
 			}
-			*/
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return err
 		},
 	}
 

--- a/x/dclauth/client/cli/tx_propose_revoke_account.go
+++ b/x/dclauth/client/cli/tx_propose_revoke_account.go
@@ -35,10 +35,13 @@ func CmdProposeRevokeAccount() *cobra.Command {
 				clientCtx.GetFromAddress(),
 				argAddress,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
+
+			// validate basic will be called in GenerateOrBroadcastTxCLI
+			err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			if cli.IsWriteInsteadReadRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForWriteRequests)
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return err
 		},
 	}
 

--- a/x/model/client/cli/query_model_version.go
+++ b/x/model/client/cli/query_model_version.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"context"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
@@ -22,28 +20,15 @@ func CmdShowModelVersion() *cobra.Command {
 		Short: "Query Model Version by combination of Vendor ID, Product ID and Software Version",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			clientCtx, err := client.GetClientQueryContext(cmd)
-			if err != nil {
-				return err
-			}
-
-			queryClient := types.NewQueryClient(clientCtx)
-
-			params := &types.QueryGetModelVersionRequest{
-				Vid:             vid,
-				Pid:             pid,
-				SoftwareVersion: softwareVersion,
-			}
-
-			res, err := queryClient.ModelVersion(context.Background(), params)
-			if cli.IsNotFound(err) {
-				return clientCtx.PrintString(cli.NotFoundOutput)
-			}
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(res)
+			clientCtx := client.GetClientContextFromCmd(cmd)
+			var res types.ModelVersion
+			return cli.QueryWithProof(
+				clientCtx,
+				types.StoreKey,
+				types.ModelVersionKeyPrefix,
+				types.ModelVersionKey(vid, pid, softwareVersion),
+				&res,
+			)
 		},
 	}
 

--- a/x/model/client/cli/query_model_versions.go
+++ b/x/model/client/cli/query_model_versions.go
@@ -1,11 +1,10 @@
 package cli
 
 import (
-	"context"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
+	"github.com/zigbee-alliance/distributed-compliance-ledger/utils/cli"
 	"github.com/zigbee-alliance/distributed-compliance-ledger/x/model/types"
 )
 
@@ -20,24 +19,15 @@ func CmdShowModelVersions() *cobra.Command {
 		Short: "Query the list of all versions for a given Device Model",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			clientCtx, err := client.GetClientQueryContext(cmd)
-			if err != nil {
-				return err
-			}
-
-			queryClient := types.NewQueryClient(clientCtx)
-
-			params := &types.QueryGetModelVersionsRequest{
-				Vid: vid,
-				Pid: pid,
-			}
-
-			res, err := queryClient.ModelVersions(context.Background(), params)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(res)
+			clientCtx := client.GetClientContextFromCmd(cmd)
+			var res types.ModelVersions
+			return cli.QueryWithProof(
+				clientCtx,
+				types.StoreKey,
+				types.ModelVersionsKeyPrefix,
+				types.ModelVersionsKey(vid, pid),
+				&res,
+			)
 		},
 	}
 

--- a/x/model/client/cli/query_vendor_products.go
+++ b/x/model/client/cli/query_vendor_products.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"context"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
@@ -18,26 +16,15 @@ func CmdShowVendorProducts() *cobra.Command {
 		Short: "Query the list of Models for the given Vendor",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			clientCtx, err := client.GetClientQueryContext(cmd)
-			if err != nil {
-				return err
-			}
-
-			queryClient := types.NewQueryClient(clientCtx)
-
-			params := &types.QueryGetVendorProductsRequest{
-				Vid: vid,
-			}
-
-			res, err := queryClient.VendorProducts(context.Background(), params)
-			if cli.IsNotFound(err) {
-				return clientCtx.PrintString(cli.NotFoundOutput)
-			}
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(res)
+			clientCtx := client.GetClientContextFromCmd(cmd)
+			var res types.VendorProducts
+			return cli.QueryWithProof(
+				clientCtx,
+				types.StoreKey,
+				types.VendorProductsKeyPrefix,
+				types.VendorProductsKey(vid),
+				&res,
+			)
 		},
 	}
 

--- a/x/model/client/cli/tx_model.go
+++ b/x/model/client/cli/tx_model.go
@@ -62,10 +62,13 @@ func CmdCreateModel() *cobra.Command {
 				supportUrl,
 				productUrl,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
+
+			// validate basic will be called in GenerateOrBroadcastTxCLI
+			err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			if cli.IsWriteInsteadReadRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForWriteRequests)
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return err
 		},
 	}
 
@@ -175,10 +178,13 @@ func CmdUpdateModel() *cobra.Command {
 				supportUrl,
 				productUrl,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
+
+			// validate basic will be called in GenerateOrBroadcastTxCLI
+			err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			if cli.IsWriteInsteadReadRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForWriteRequests)
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return err
 		},
 	}
 
@@ -241,10 +247,13 @@ func CmdDeleteModel() *cobra.Command {
 				vid,
 				pid,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
+
+			// validate basic will be called in GenerateOrBroadcastTxCLI
+			err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			if cli.IsWriteInsteadReadRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForWriteRequests)
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return err
 		},
 	}
 

--- a/x/model/client/cli/tx_model_version.go
+++ b/x/model/client/cli/tx_model_version.go
@@ -53,10 +53,13 @@ func CmdCreateModelVersion() *cobra.Command {
 				maxApplicableSoftwareVersion,
 				releaseNotesUrl,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
+
+			// validate basic will be called in GenerateOrBroadcastTxCLI
+			err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			if cli.IsWriteInsteadReadRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForWriteRequests)
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return err
 		},
 	}
 	cmd.Flags().Int32Var(&vid, FlagVid, 0,
@@ -145,10 +148,13 @@ func CmdUpdateModelVersion() *cobra.Command {
 				maxApplicableSoftwareVersion,
 				releaseNotesUrl,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
+
+			// validate basic will be called in GenerateOrBroadcastTxCLI
+			err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			if cli.IsWriteInsteadReadRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForWriteRequests)
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return err
 		},
 	}
 

--- a/x/pki/client/cli/query_approved_certificates.go
+++ b/x/pki/client/cli/query_approved_certificates.go
@@ -6,7 +6,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"github.com/zigbee-alliance/distributed-compliance-ledger/utils/cli"
 	"github.com/zigbee-alliance/distributed-compliance-ledger/x/pki/types"
 )
@@ -30,6 +29,9 @@ func CmdListApprovedCertificates() *cobra.Command {
 			}
 
 			res, err := queryClient.ApprovedCertificatesAll(context.Background(), params)
+			if cli.IsKeyNotFoundRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForListQueries)
+			}
 			if err != nil {
 				return err
 			}
@@ -45,6 +47,11 @@ func CmdListApprovedCertificates() *cobra.Command {
 }
 
 func CmdShowApprovedCertificates() *cobra.Command {
+	var (
+		subject      string
+		subjectKeyID string
+	)
+
 	cmd := &cobra.Command{
 		Use: "x509-cert",
 		Short: "Gets certificates (either root, intermediate or leaf) " +
@@ -52,31 +59,19 @@ func CmdShowApprovedCertificates() *cobra.Command {
 		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx := client.GetClientContextFromCmd(cmd)
-
-			queryClient := types.NewQueryClient(clientCtx)
-
-			subject := viper.GetString(FlagSubject)
-			subjectKeyID := viper.GetString(FlagSubjectKeyID)
-
-			params := &types.QueryGetApprovedCertificatesRequest{
-				Subject:      subject,
-				SubjectKeyId: subjectKeyID,
-			}
-
-			res, err := queryClient.ApprovedCertificates(context.Background(), params)
-			if cli.IsNotFound(err) {
-				return clientCtx.PrintString(cli.NotFoundOutput)
-			}
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(res)
+			var res types.ApprovedCertificates
+			return cli.QueryWithProof(
+				clientCtx,
+				types.StoreKey,
+				types.ApprovedCertificatesKeyPrefix,
+				types.ApprovedCertificatesKey(subject, subjectKeyID),
+				&res,
+			)
 		},
 	}
 
-	cmd.Flags().StringP(FlagSubject, FlagSubjectShortcut, "", "Certificate's subject")
-	cmd.Flags().StringP(FlagSubjectKeyID, FlagSubjectKeyIDShortcut, "", "Certificate's subject key id (hex)")
+	cmd.Flags().StringVarP(&subject, FlagSubject, FlagSubjectShortcut, "", "Certificate's subject")
+	cmd.Flags().StringVarP(&subjectKeyID, FlagSubjectKeyID, FlagSubjectKeyIDShortcut, "", "Certificate's subject key id (hex)")
 	flags.AddQueryFlagsToCmd(cmd)
 
 	_ = cmd.MarkFlagRequired(FlagSubject)

--- a/x/pki/client/cli/query_approved_certificates_by_subject.go
+++ b/x/pki/client/cli/query_approved_certificates_by_subject.go
@@ -1,45 +1,36 @@
 package cli
 
 import (
-	"context"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"github.com/zigbee-alliance/distributed-compliance-ledger/utils/cli"
 	"github.com/zigbee-alliance/distributed-compliance-ledger/x/pki/types"
 )
 
 func CmdShowApprovedCertificatesBySubject() *cobra.Command {
+	var (
+		subject string
+	)
+
 	cmd := &cobra.Command{
 		Use:   "all-subject-x509-certs",
 		Short: "Gets all certificates (root, intermediate and leaf) associated with subject",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx := client.GetClientContextFromCmd(cmd)
-
-			queryClient := types.NewQueryClient(clientCtx)
-
-			subject := viper.GetString(FlagSubject)
-
-			params := &types.QueryGetApprovedCertificatesBySubjectRequest{
-				Subject: subject,
-			}
-
-			res, err := queryClient.ApprovedCertificatesBySubject(context.Background(), params)
-			if cli.IsNotFound(err) {
-				return clientCtx.PrintString(cli.NotFoundOutput)
-			}
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(res)
+			var res types.ApprovedCertificatesBySubject
+			return cli.QueryWithProof(
+				clientCtx,
+				types.StoreKey,
+				types.ApprovedCertificatesBySubjectKeyPrefix,
+				types.ApprovedCertificatesBySubjectKey(subject),
+				&res,
+			)
 		},
 	}
 
-	cmd.Flags().StringP(FlagSubject, FlagSubjectShortcut, "", "Certificate's subject")
+	cmd.Flags().StringVarP(&subject, FlagSubject, FlagSubjectShortcut, "", "Certificate's subject")
 	flags.AddQueryFlagsToCmd(cmd)
 
 	_ = cmd.MarkFlagRequired(FlagSubject)

--- a/x/pki/client/cli/query_approved_certificates_by_subject.go
+++ b/x/pki/client/cli/query_approved_certificates_by_subject.go
@@ -9,9 +9,7 @@ import (
 )
 
 func CmdShowApprovedCertificatesBySubject() *cobra.Command {
-	var (
-		subject string
-	)
+	var subject string
 
 	cmd := &cobra.Command{
 		Use:   "all-subject-x509-certs",

--- a/x/pki/client/cli/query_approved_root_certificates.go
+++ b/x/pki/client/cli/query_approved_root_certificates.go
@@ -1,11 +1,10 @@
 package cli
 
 import (
-	"context"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
+	"github.com/zigbee-alliance/distributed-compliance-ledger/utils/cli"
 	"github.com/zigbee-alliance/distributed-compliance-ledger/x/pki/types"
 )
 
@@ -16,17 +15,14 @@ func CmdShowApprovedRootCertificates() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx := client.GetClientContextFromCmd(cmd)
-
-			queryClient := types.NewQueryClient(clientCtx)
-
-			params := &types.QueryGetApprovedRootCertificatesRequest{}
-
-			res, err := queryClient.ApprovedRootCertificates(context.Background(), params)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(res)
+			var res types.ApprovedRootCertificates
+			return cli.QueryWithProof(
+				clientCtx,
+				types.StoreKey,
+				types.ApprovedRootCertificatesKeyPrefix,
+				types.ApprovedRootCertificatesKey,
+				&res,
+			)
 		},
 	}
 

--- a/x/pki/client/cli/query_approved_root_certificates.go
+++ b/x/pki/client/cli/query_approved_root_certificates.go
@@ -16,7 +16,7 @@ func CmdShowApprovedRootCertificates() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx := client.GetClientContextFromCmd(cmd)
 			var res types.ApprovedRootCertificates
-			return cli.QueryWithProof(
+			return cli.QueryWithProofList(
 				clientCtx,
 				types.StoreKey,
 				types.ApprovedRootCertificatesKeyPrefix,

--- a/x/pki/client/cli/query_child_certificates.go
+++ b/x/pki/client/cli/query_child_certificates.go
@@ -1,48 +1,38 @@
 package cli
 
 import (
-	"context"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"github.com/zigbee-alliance/distributed-compliance-ledger/utils/cli"
 	"github.com/zigbee-alliance/distributed-compliance-ledger/x/pki/types"
 )
 
 func CmdShowChildCertificates() *cobra.Command {
+	var (
+		subject      string
+		subjectKeyID string
+	)
+
 	cmd := &cobra.Command{
 		Use:   "all-child-x509-certs",
 		Short: "Gets all child certificates for the given certificate",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx := client.GetClientContextFromCmd(cmd)
-
-			queryClient := types.NewQueryClient(clientCtx)
-
-			subject := viper.GetString(FlagSubject)
-			subjectKeyID := viper.GetString(FlagSubjectKeyID)
-
-			params := &types.QueryGetChildCertificatesRequest{
-				Issuer:         subject,
-				AuthorityKeyId: subjectKeyID,
-			}
-
-			res, err := queryClient.ChildCertificates(context.Background(), params)
-			if cli.IsNotFound(err) {
-				return clientCtx.PrintString(cli.NotFoundOutput)
-			}
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(res)
+			var res types.ChildCertificates
+			return cli.QueryWithProof(
+				clientCtx,
+				types.StoreKey,
+				types.ChildCertificatesKeyPrefix,
+				types.ChildCertificatesKey(subject, subjectKeyID),
+				&res,
+			)
 		},
 	}
 
-	cmd.Flags().StringP(FlagSubject, FlagSubjectShortcut, "", "Certificate's subject")
-	cmd.Flags().StringP(FlagSubjectKeyID, FlagSubjectKeyIDShortcut, "", "Certificate's subject key id (hex)")
+	cmd.Flags().StringVarP(&subject, FlagSubject, FlagSubjectShortcut, "", "Certificate's subject")
+	cmd.Flags().StringVarP(&subjectKeyID, FlagSubjectKeyID, FlagSubjectKeyIDShortcut, "", "Certificate's subject key id (hex)")
 	flags.AddQueryFlagsToCmd(cmd)
 
 	_ = cmd.MarkFlagRequired(FlagSubject)

--- a/x/pki/client/cli/query_proposed_certificate_revocation.go
+++ b/x/pki/client/cli/query_proposed_certificate_revocation.go
@@ -6,7 +6,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"github.com/zigbee-alliance/distributed-compliance-ledger/utils/cli"
 	"github.com/zigbee-alliance/distributed-compliance-ledger/x/pki/types"
 )
@@ -30,6 +29,9 @@ func CmdListProposedCertificateRevocation() *cobra.Command {
 			}
 
 			res, err := queryClient.ProposedCertificateRevocationAll(context.Background(), params)
+			if cli.IsKeyNotFoundRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForListQueries)
+			}
 			if err != nil {
 				return err
 			}
@@ -45,6 +47,11 @@ func CmdListProposedCertificateRevocation() *cobra.Command {
 }
 
 func CmdShowProposedCertificateRevocation() *cobra.Command {
+	var (
+		subject      string
+		subjectKeyID string
+	)
+
 	cmd := &cobra.Command{
 		Use: "proposed-x509-root-cert-to-revoke",
 		Short: "Gets a proposed but not approved root certificate to be revoked " +
@@ -52,31 +59,19 @@ func CmdShowProposedCertificateRevocation() *cobra.Command {
 		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx := client.GetClientContextFromCmd(cmd)
-
-			queryClient := types.NewQueryClient(clientCtx)
-
-			subject := viper.GetString(FlagSubject)
-			subjectKeyID := viper.GetString(FlagSubjectKeyID)
-
-			params := &types.QueryGetProposedCertificateRevocationRequest{
-				Subject:      subject,
-				SubjectKeyId: subjectKeyID,
-			}
-
-			res, err := queryClient.ProposedCertificateRevocation(context.Background(), params)
-			if cli.IsNotFound(err) {
-				return clientCtx.PrintString(cli.NotFoundOutput)
-			}
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(res)
+			var res types.ProposedCertificateRevocation
+			return cli.QueryWithProof(
+				clientCtx,
+				types.StoreKey,
+				types.ProposedCertificateRevocationKeyPrefix,
+				types.ProposedCertificateRevocationKey(subject, subjectKeyID),
+				&res,
+			)
 		},
 	}
 
-	cmd.Flags().StringP(FlagSubject, FlagSubjectShortcut, "", "Certificate's subject")
-	cmd.Flags().StringP(FlagSubjectKeyID, FlagSubjectKeyIDShortcut, "", "Certificate's subject key id (hex)")
+	cmd.Flags().StringVarP(&subject, FlagSubject, FlagSubjectShortcut, "", "Certificate's subject")
+	cmd.Flags().StringVarP(&subjectKeyID, FlagSubjectKeyID, FlagSubjectKeyIDShortcut, "", "Certificate's subject key id (hex)")
 	flags.AddQueryFlagsToCmd(cmd)
 
 	_ = cmd.MarkFlagRequired(FlagSubject)

--- a/x/pki/client/cli/query_revoked_certificates.go
+++ b/x/pki/client/cli/query_revoked_certificates.go
@@ -6,7 +6,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"github.com/zigbee-alliance/distributed-compliance-ledger/utils/cli"
 	"github.com/zigbee-alliance/distributed-compliance-ledger/x/pki/types"
 )
@@ -30,6 +29,9 @@ func CmdListRevokedCertificates() *cobra.Command {
 			}
 
 			res, err := queryClient.RevokedCertificatesAll(context.Background(), params)
+			if cli.IsKeyNotFoundRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForListQueries)
+			}
 			if err != nil {
 				return err
 			}
@@ -45,6 +47,11 @@ func CmdListRevokedCertificates() *cobra.Command {
 }
 
 func CmdShowRevokedCertificates() *cobra.Command {
+	var (
+		subject      string
+		subjectKeyID string
+	)
+
 	cmd := &cobra.Command{
 		Use: "revoked-x509-cert",
 		Short: "Gets revoked certificates (either root, intermediate or leaf) " +
@@ -52,31 +59,19 @@ func CmdShowRevokedCertificates() *cobra.Command {
 		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx := client.GetClientContextFromCmd(cmd)
-
-			queryClient := types.NewQueryClient(clientCtx)
-
-			subject := viper.GetString(FlagSubject)
-			subjectKeyID := viper.GetString(FlagSubjectKeyID)
-
-			params := &types.QueryGetRevokedCertificatesRequest{
-				Subject:      subject,
-				SubjectKeyId: subjectKeyID,
-			}
-
-			res, err := queryClient.RevokedCertificates(context.Background(), params)
-			if cli.IsNotFound(err) {
-				return clientCtx.PrintString(cli.NotFoundOutput)
-			}
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(res)
+			var res types.RevokedCertificates
+			return cli.QueryWithProof(
+				clientCtx,
+				types.StoreKey,
+				types.RevokedCertificatesKeyPrefix,
+				types.RevokedCertificatesKey(subject, subjectKeyID),
+				&res,
+			)
 		},
 	}
 
-	cmd.Flags().StringP(FlagSubject, FlagSubjectShortcut, "", "Certificate's subject")
-	cmd.Flags().StringP(FlagSubjectKeyID, FlagSubjectKeyIDShortcut, "", "Certificate's subject key id (hex)")
+	cmd.Flags().StringVarP(&subject, FlagSubject, FlagSubjectShortcut, "", "Certificate's subject")
+	cmd.Flags().StringVarP(&subjectKeyID, FlagSubjectKeyID, FlagSubjectKeyIDShortcut, "", "Certificate's subject key id (hex)")
 	flags.AddQueryFlagsToCmd(cmd)
 
 	_ = cmd.MarkFlagRequired(FlagSubject)

--- a/x/pki/client/cli/query_revoked_root_certificates.go
+++ b/x/pki/client/cli/query_revoked_root_certificates.go
@@ -1,11 +1,10 @@
 package cli
 
 import (
-	"context"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
+	"github.com/zigbee-alliance/distributed-compliance-ledger/utils/cli"
 	"github.com/zigbee-alliance/distributed-compliance-ledger/x/pki/types"
 )
 
@@ -16,17 +15,14 @@ func CmdShowRevokedRootCertificates() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx := client.GetClientContextFromCmd(cmd)
-
-			queryClient := types.NewQueryClient(clientCtx)
-
-			params := &types.QueryGetRevokedRootCertificatesRequest{}
-
-			res, err := queryClient.RevokedRootCertificates(context.Background(), params)
-			if err != nil {
-				return err
-			}
-
-			return clientCtx.PrintProto(res)
+			var res types.RevokedRootCertificates
+			return cli.QueryWithProof(
+				clientCtx,
+				types.StoreKey,
+				types.RevokedRootCertificatesKeyPrefix,
+				types.RevokedRootCertificatesKey,
+				&res,
+			)
 		},
 	}
 

--- a/x/pki/client/cli/query_revoked_root_certificates.go
+++ b/x/pki/client/cli/query_revoked_root_certificates.go
@@ -16,7 +16,7 @@ func CmdShowRevokedRootCertificates() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx := client.GetClientContextFromCmd(cmd)
 			var res types.RevokedRootCertificates
-			return cli.QueryWithProof(
+			return cli.QueryWithProofList(
 				clientCtx,
 				types.StoreKey,
 				types.RevokedRootCertificatesKeyPrefix,

--- a/x/pki/client/cli/tx_add_x_509_cert.go
+++ b/x/pki/client/cli/tx_add_x_509_cert.go
@@ -35,10 +35,12 @@ func CmdAddX509Cert() *cobra.Command {
 				clientCtx.GetFromAddress().String(),
 				cert,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
+			// validate basic will be called in GenerateOrBroadcastTxCLI
+			err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			if cli.IsWriteInsteadReadRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForWriteRequests)
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return err
 		},
 	}
 

--- a/x/pki/client/cli/tx_approve_add_x_509_root_cert.go
+++ b/x/pki/client/cli/tx_approve_add_x_509_root_cert.go
@@ -33,10 +33,12 @@ func CmdApproveAddX509RootCert() *cobra.Command {
 				subject,
 				subjectKeyId,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
+			// validate basic will be called in GenerateOrBroadcastTxCLI
+			err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			if cli.IsWriteInsteadReadRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForWriteRequests)
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return err
 		},
 	}
 

--- a/x/pki/client/cli/tx_approve_revoke_x_509_root_cert.go
+++ b/x/pki/client/cli/tx_approve_revoke_x_509_root_cert.go
@@ -34,10 +34,12 @@ func CmdApproveRevokeX509RootCert() *cobra.Command {
 				subject,
 				subjectKeyID,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
+			// validate basic will be called in GenerateOrBroadcastTxCLI
+			err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			if cli.IsWriteInsteadReadRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForWriteRequests)
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return err
 		},
 	}
 

--- a/x/pki/client/cli/tx_propose_add_x_509_root_cert.go
+++ b/x/pki/client/cli/tx_propose_add_x_509_root_cert.go
@@ -34,10 +34,12 @@ func CmdProposeAddX509RootCert() *cobra.Command {
 				clientCtx.GetFromAddress().String(),
 				cert,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
+			// validate basic will be called in GenerateOrBroadcastTxCLI
+			err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			if cli.IsWriteInsteadReadRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForWriteRequests)
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return err
 		},
 	}
 

--- a/x/pki/client/cli/tx_propose_revoke_x_509_root_cert.go
+++ b/x/pki/client/cli/tx_propose_revoke_x_509_root_cert.go
@@ -34,10 +34,12 @@ func CmdProposeRevokeX509RootCert() *cobra.Command {
 				subject,
 				subjectKeyID,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
+			// validate basic will be called in GenerateOrBroadcastTxCLI
+			err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			if cli.IsWriteInsteadReadRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForWriteRequests)
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return err
 		},
 	}
 

--- a/x/pki/client/cli/tx_revoke_x_509_cert.go
+++ b/x/pki/client/cli/tx_revoke_x_509_cert.go
@@ -34,10 +34,12 @@ func CmdRevokeX509Cert() *cobra.Command {
 				subject,
 				subjectKeyID,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
+			// validate basic will be called in GenerateOrBroadcastTxCLI
+			err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			if cli.IsWriteInsteadReadRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForWriteRequests)
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return err
 		},
 	}
 

--- a/x/pki/keeper/approved_root_certificates.go
+++ b/x/pki/keeper/approved_root_certificates.go
@@ -8,16 +8,16 @@ import (
 
 // SetApprovedRootCertificates set approvedRootCertificates in the store.
 func (k Keeper) SetApprovedRootCertificates(ctx sdk.Context, approvedRootCertificates types.ApprovedRootCertificates) {
-	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.ApprovedRootCertificatesKey))
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.ApprovedRootCertificatesKeyPrefix))
 	b := k.cdc.MustMarshal(&approvedRootCertificates)
-	store.Set([]byte{0}, b)
+	store.Set(types.ApprovedRootCertificatesKey, b)
 }
 
 // GetApprovedRootCertificates returns approvedRootCertificates.
 func (k Keeper) GetApprovedRootCertificates(ctx sdk.Context) (val types.ApprovedRootCertificates, found bool) {
-	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.ApprovedRootCertificatesKey))
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.ApprovedRootCertificatesKeyPrefix))
 
-	b := store.Get([]byte{0})
+	b := store.Get(types.ApprovedRootCertificatesKey)
 	if b == nil {
 		return val, false
 	}
@@ -28,8 +28,8 @@ func (k Keeper) GetApprovedRootCertificates(ctx sdk.Context) (val types.Approved
 
 // RemoveApprovedRootCertificates removes approvedRootCertificates from the store.
 func (k Keeper) RemoveApprovedRootCertificates(ctx sdk.Context) {
-	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.ApprovedRootCertificatesKey))
-	store.Delete([]byte{0})
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.ApprovedRootCertificatesKeyPrefix))
+	store.Delete(types.ApprovedRootCertificatesKey)
 }
 
 // Add root certificate to the list.

--- a/x/pki/keeper/revoked_root_certificates.go
+++ b/x/pki/keeper/revoked_root_certificates.go
@@ -8,16 +8,16 @@ import (
 
 // SetRevokedRootCertificates set revokedRootCertificates in the store.
 func (k Keeper) SetRevokedRootCertificates(ctx sdk.Context, revokedRootCertificates types.RevokedRootCertificates) {
-	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.RevokedRootCertificatesKey))
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.RevokedRootCertificatesKeyPrefix))
 	b := k.cdc.MustMarshal(&revokedRootCertificates)
-	store.Set([]byte{0}, b)
+	store.Set(types.RevokedRootCertificatesKey, b)
 }
 
 // GetRevokedRootCertificates returns revokedRootCertificates.
 func (k Keeper) GetRevokedRootCertificates(ctx sdk.Context) (val types.RevokedRootCertificates, found bool) {
-	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.RevokedRootCertificatesKey))
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.RevokedRootCertificatesKeyPrefix))
 
-	b := store.Get([]byte{0})
+	b := store.Get(types.RevokedRootCertificatesKey)
 	if b == nil {
 		return val, false
 	}
@@ -28,8 +28,8 @@ func (k Keeper) GetRevokedRootCertificates(ctx sdk.Context) (val types.RevokedRo
 
 // RemoveRevokedRootCertificates removes revokedRootCertificates from the store.
 func (k Keeper) RemoveRevokedRootCertificates(ctx sdk.Context) {
-	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.RevokedRootCertificatesKey))
-	store.Delete([]byte{0})
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.RevokedRootCertificatesKeyPrefix))
+	store.Delete(types.RevokedRootCertificatesKey)
 }
 
 // Add revoked root certificate to the list.

--- a/x/pki/types/keys.go
+++ b/x/pki/types/keys.go
@@ -22,9 +22,11 @@ func KeyPrefix(p string) []byte {
 }
 
 const (
-	ApprovedRootCertificatesKey = "ApprovedRootCertificates-value-"
+	ApprovedRootCertificatesKeyPrefix = "ApprovedRootCertificates/value/"
+	RevokedRootCertificatesKeyPrefix  = "RevokedRootCertificates/value/"
 )
 
-const (
-	RevokedRootCertificatesKey = "RevokedRootCertificates-value-"
+var (
+	ApprovedRootCertificatesKey = []byte{0}
+	RevokedRootCertificatesKey  = []byte{0}
 )

--- a/x/validator/client/cli/tx_create_validator.go
+++ b/x/validator/client/cli/tx_create_validator.go
@@ -35,7 +35,11 @@ func CmdCreateValidator() *cobra.Command {
 				return err
 			}
 
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			if cli.IsWriteInsteadReadRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForWriteRequests)
+			}
+			return err
 		},
 	}
 

--- a/x/vendorinfo/client/cli/query_vendor_info.go
+++ b/x/vendorinfo/client/cli/query_vendor_info.go
@@ -53,21 +53,47 @@ func CmdShowVendorInfo() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx := client.GetClientContextFromCmd(cmd)
 
-			queryClient := types.NewQueryClient(clientCtx)
+			// node, err := clientCtx.GetNode()
+			// if err != nil {
+			// 	return err
+			// }
+			// status, err := node.Status(context.Background())
+			// if err != nil {
+			// 	return err
+			// }
+			// height := status.SyncInfo.LatestBlockHeight - 1
+			// clientCtx = clientCtx.WithHeight(height)
+			// println(clientCtx.Height)
 
-			params := &types.QueryGetVendorInfoRequest{
-				VendorID: vid,
-			}
+			key := append(types.KeyPrefix(types.VendorInfoKeyPrefix), types.VendorInfoKey(vid)...)
+			resBytes, _, err := clientCtx.QueryStore(key, types.StoreKey)
 
-			res, err := queryClient.VendorInfo(context.Background(), params)
-			if cli.IsNotFound(err) {
-				return clientCtx.PrintString(cli.NotFoundOutput)
-			}
 			if err != nil {
 				return err
 			}
+			if resBytes == nil {
+				return clientCtx.PrintString(cli.NotFoundOutput)
+			}
 
-			return clientCtx.PrintProto(res)
+			var res types.VendorInfo
+			clientCtx.Codec.MustUnmarshal(resBytes, &res)
+			return clientCtx.PrintProto(&res)
+
+			// queryClient := types.NewQueryClient(clientCtx)
+
+			// params := &types.QueryGetVendorInfoRequest{
+			// 	VendorID: vid,
+			// }
+
+			// res, err := queryClient.VendorInfo(context.Background(), params)
+			// if cli.IsNotFound(err) {
+			// 	return clientCtx.PrintString(cli.NotFoundOutput)
+			// }
+			// if err != nil {
+			// 	return err
+			// }
+
+			// return clientCtx.PrintProto(res)
 		},
 	}
 

--- a/x/vendorinfo/client/cli/query_vendor_info.go
+++ b/x/vendorinfo/client/cli/query_vendor_info.go
@@ -30,7 +30,7 @@ func CmdListVendorInfo() *cobra.Command {
 
 			res, err := queryClient.VendorInfoAll(context.Background(), params)
 			if cli.IsKeyNotFoundRpcError(err) {
-				return clientCtx.PrintString(cli.LightClientForListQueries)
+				return clientCtx.PrintString(cli.LightClientProxyForListQueries)
 			}
 			if err != nil {
 				return err
@@ -55,19 +55,14 @@ func CmdShowVendorInfo() *cobra.Command {
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx := client.GetClientContextFromCmd(cmd)
-
-			key := append(types.KeyPrefix(types.VendorInfoKeyPrefix), types.VendorInfoKey(vid)...)
-			resBytes, _, err := clientCtx.QueryStore(key, types.StoreKey)
-			if err != nil {
-				return err
-			}
-			if resBytes == nil {
-				return clientCtx.PrintString(cli.NotFoundOutput)
-			}
-
 			var res types.VendorInfo
-			clientCtx.Codec.MustUnmarshal(resBytes, &res)
-			return clientCtx.PrintProto(&res)
+			return cli.QueryWithProof(
+				clientCtx,
+				types.StoreKey,
+				types.VendorInfoKeyPrefix,
+				types.VendorInfoKey(vid),
+				&res,
+			)
 		},
 	}
 

--- a/x/vendorinfo/client/cli/query_vendor_info.go
+++ b/x/vendorinfo/client/cli/query_vendor_info.go
@@ -29,6 +29,9 @@ func CmdListVendorInfo() *cobra.Command {
 			}
 
 			res, err := queryClient.VendorInfoAll(context.Background(), params)
+			if cli.IsKeyNotFoundRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientForListQueries)
+			}
 			if err != nil {
 				return err
 			}
@@ -53,21 +56,8 @@ func CmdShowVendorInfo() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx := client.GetClientContextFromCmd(cmd)
 
-			// node, err := clientCtx.GetNode()
-			// if err != nil {
-			// 	return err
-			// }
-			// status, err := node.Status(context.Background())
-			// if err != nil {
-			// 	return err
-			// }
-			// height := status.SyncInfo.LatestBlockHeight - 1
-			// clientCtx = clientCtx.WithHeight(height)
-			// println(clientCtx.Height)
-
 			key := append(types.KeyPrefix(types.VendorInfoKeyPrefix), types.VendorInfoKey(vid)...)
 			resBytes, _, err := clientCtx.QueryStore(key, types.StoreKey)
-
 			if err != nil {
 				return err
 			}
@@ -78,22 +68,6 @@ func CmdShowVendorInfo() *cobra.Command {
 			var res types.VendorInfo
 			clientCtx.Codec.MustUnmarshal(resBytes, &res)
 			return clientCtx.PrintProto(&res)
-
-			// queryClient := types.NewQueryClient(clientCtx)
-
-			// params := &types.QueryGetVendorInfoRequest{
-			// 	VendorID: vid,
-			// }
-
-			// res, err := queryClient.VendorInfo(context.Background(), params)
-			// if cli.IsNotFound(err) {
-			// 	return clientCtx.PrintString(cli.NotFoundOutput)
-			// }
-			// if err != nil {
-			// 	return err
-			// }
-
-			// return clientCtx.PrintProto(res)
 		},
 	}
 

--- a/x/vendorinfo/client/cli/tx_vendor_info.go
+++ b/x/vendorinfo/client/cli/tx_vendor_info.go
@@ -36,10 +36,13 @@ func CmdCreateVendorInfo() *cobra.Command {
 				companyPreferredName,
 				vendorLandingPageURL,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
+
+			// validate basic will be called in GenerateOrBroadcastTxCLI
+			err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			if cli.IsWriteInsteadReadRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForWriteRequests)
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return err
 		},
 	}
 
@@ -90,10 +93,13 @@ func CmdUpdateVendorInfo() *cobra.Command {
 				companyPreferredName,
 				vendorLandingPageURL,
 			)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
+
+			// validate basic will be called in GenerateOrBroadcastTxCLI
+			err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			if cli.IsWriteInsteadReadRpcError(err) {
+				return clientCtx.PrintString(cli.LightClientProxyForWriteRequests)
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			return err
 		},
 	}
 


### PR DESCRIPTION
- Add `light` command to start a light client proxy server (command code is mostly copied from https://github.com/tendermint/tendermint/blob/master/cmd/tendermint/commands/light.go with a fix to register IAVL proof verifiers)
- have to fork Tendermint and depend on that fork with fixes in Tendermint light client
  - https://github.com/zigbee-alliance/tendermint/tree/v34.14-light-client-fix
  - https://github.com/zigbee-alliance/tendermint/releases/tag/v0.34.140
  - this is basically https://github.com/zigbee-alliance/tendermint/releases/tag/v0.34.14 with fixes for https://github.com/tendermint/tendermint/issues/7640 and https://github.com/tendermint/tendermint/issues/7641
- use `QueryStore` (Tendermint RPC) instead of cosmos custom queries for single value queries in CLI
- return a proper warning in CLI if Light Client Proxy is used with write requests or multi value queries
- fixed pruning strategy (no need to keep all heights forever, now we keep only latest 100 and every 100th height).
- add docs and how-to for light client proxy server node
- improved docs