### PR TITLE
Improve Dockerfiles

### DIFF
--- a/.github/workflows/on-demand_docker.yml
+++ b/.github/workflows/on-demand_docker.yml
@@ -1,0 +1,38 @@
+---
+# Copyright 2022 Samsung Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Check Docker files
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '**/Dockerfile'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '**/Dockerfile'
+
+jobs:
+  check-dockerfile-lint:
+    name: Check Dockerfile lint issues (hadolint)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hadolint/hadolint-action@v2.1.0
+        with:
+          recursive: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,17 +19,17 @@
 ############################
 # STEP 1 build cosmovisor
 ############################
-FROM golang:alpine AS builder
+FROM golang:alpine3.15 AS builder
 
 # git is required for fetching the dependencies.
-RUN apk update && apk add --no-cache git
-
-RUN go install github.com/cosmos/cosmos-sdk/cosmovisor/cmd/cosmovisor@v1.0.0
+RUN apk --no-cache add \
+  git=2.34.2-r0 && \
+  go install github.com/cosmos/cosmos-sdk/cosmovisor/cmd/cosmovisor@v1.0.0
 
 ############################
 # STEP 2 build node image
 ############################
-FROM alpine:latest
+FROM alpine:3.15
 
 COPY --from=builder /go/bin/cosmovisor /usr/bin/
 

--- a/integration_tests/deploy/Dockerfile
+++ b/integration_tests/deploy/Dockerfile
@@ -17,11 +17,11 @@
 ################################################################################
 FROM jrei/systemd-ubuntu:20.04
 
-RUN apt-get update && apt-get install -y \
-        sudo \
-        curl \
-        netcat \
-        iproute2 \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        sudo=1.8.31-1ubuntu1.2 \
+        curl=7.68.0-1ubuntu2.10 \
+        netcat=1.206-1ubuntu1 \
+        iproute2=5.5.0-1ubuntu1 \
     && rm -rf /var/lib/apt/lists/*
 
 # test user

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,63 +1,66 @@
+# Copyright 2022
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ################################################################################
 # Image of a machine with installed swagger-combine and starport.
 ################################################################################
 
-FROM node
+FROM alpine:3.15 as builder
 
-# Install golang
-ARG GO_VERSION
-ENV GO_VERSION=${GO_VERSION:-1.17.2}
-ENV BASH_ENV=/etc/bashrc
-ENV PATH="${PATH}:/usr/local/go/bin"
-RUN curl -L https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz -o /tmp/go.tar.gz \
-    && rm -rf /usr/local/go \
-    && tar -C /usr/local -xzf /tmp/go.tar.gz \ 
-    && go version \
-    && rm -f /tmp/go.tar.gz
+ARG STARPORT_VERSION
 
-# Install protoc
-ARG PROTOC_VERSION
-ENV PROTOC_VERSION=${PROTOC_VERSION:-3.19.4}
-RUN PROTOC_ZIP=protoc-${PROTOC_VERSION}-linux-x86_64.zip \
-    && curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ZIP} \
-    && unzip -o $PROTOC_ZIP -d /usr/local bin/protoc \
-    && unzip -o $PROTOC_ZIP -d /usr/local 'include/*' \
-    && rm -f $PROTOC_ZIP
+ENV STARPORT_VERSION=${STARPORT_VERSION:-v0.19.3}
+#ENV STARPORT_VERSION=${STARPORT_VERSION:-dev}
 
-# Install grpc-gateway tools
+RUN apk --no-cache add \
+  make=4.3-r0 \
+  go=1.17.9-r0 \
+  git=2.34.2-r0 \
+  bash=5.1.16-r0
+
+# Install starport
+WORKDIR /tmp
+RUN git clone https://github.com/tendermint/starport.git \
+  && if [ "$STARPORT_VERSION" != "dev"  ]; then \
+    git -C /tmp/starport checkout -b ${STARPORT_VERSION:-v0.19.3} tags/${STARPORT_VERSION:-v0.19.3}; \
+  fi \
+  && make -C /tmp/starport build
+
+FROM alpine:3.15
+
 ENV PROTOC_GEN_GRPC_GATEWAY_VERSION=v2.8.0
 ENV PROTOC_GEN_OPENAPIV2_VERSION=v2.8.0
 ENV PROTOC_GEN_SWAGGER_VERSION=v1.16.0
-
-RUN go install \
-        github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@${PROTOC_GEN_GRPC_GATEWAY_VERSION} \
-        github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@${PROTOC_GEN_OPENAPIV2_VERSION}
-
-RUN go install \
-    github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@${PROTOC_GEN_SWAGGER_VERSION}
-
-RUN npm install -g swagger-combine
-
-
-# Install starport
-ARG STARPORT_VERSION
-ENV STARPORT_VERSION=${STARPORT_VERSION:-0.19.3}
-#ENV STARPORT_VERSION=${STARPORT_VERSION:-dev}
-
-RUN if [ "$STARPORT_VERSION" = "dev" ]; then \
-      curl -L https://github.com/tendermint/starport/archive/refs/heads/develop.zip -o /tmp/starport.zip && \
-      cd /tmp \
-        && unzip starport.zip \
-        && cd starport-develop \
-        && make build \
-        && cp ./dist/starport /usr/local/bin; \
-    else \
-      curl https://get.starport.network/starport@v${STARPORT_VERSION}! -o /tmp/startport \
-      && bash /tmp/startport \
-      && rm /tmp/startport; \
-    fi  
-
 ENV PATH="/root/go/bin:${PATH}"
-ENV PATH="${PATH}:/usr/local/bin"
+
+COPY --from=builder /tmp/starport/dist/starport /usr/local/bin/starport
+
+RUN apk --no-cache add \
+  bash=5.1.16-r0 \
+  git=2.34.2-r0 \
+  go=1.17.9-r0 \
+  protobuf=3.18.1-r1 \
+  protobuf-dev=3.18.1-r1 \
+  npm=8.1.3-r0 \
+  && npm install -g swagger-combine@1.4.0
+
+# Install grpc-gateway tools
+
+RUN go install \
+  github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@${PROTOC_GEN_GRPC_GATEWAY_VERSION} \
+  github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@${PROTOC_GEN_OPENAPIV2_VERSION} \
+  && go install \
+  github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger@${PROTOC_GEN_SWAGGER_VERSION}
 
 WORKDIR /dcl

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,7 +20,7 @@ docker build -t <name[:tag]> ./scripts
 Run docker container (from the root of the project) in an interactive mode:
 
 ```bash
-docker run -it -v "$PWD":/dcl <name[:tag]> /bin/bash
+docker run -it --rm -v "$PWD":/dcl <name[:tag]> /bin/bash
 ```
 
 ## Scripts

--- a/scripts/cosmos-swagger-gen.sh
+++ b/scripts/cosmos-swagger-gen.sh
@@ -1,22 +1,37 @@
 #!/usr/bin/env bash
-# possible values: "base" or "tx"
+# Copyright 2022
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 TYPE=${1:-tx}
+valid_values=(base tx)
+if ! printf '%s\0' "${valid_values[@]}" | grep -qxFe "$TYPE"; then
+    printf '%s\n' "$TYPE is an invalid value"
+    exit 1
+fi
 
 echo "Generating Cosmos openapi for '$TYPE'"
 CONFIG_FILE="$PWD/scripts/swagger/config/cosmos-$TYPE-config.json"
 OUTPUT_FILE="$PWD/docs/static/cosmos-$TYPE-openapi.json"
-
 COSMOS_SDK_VERSION="v0.44.4"
 
-rm -rf ./tmp-swagger-gen
 mkdir -p ./tmp-swagger-gen
-
-# clone cosmos-sdk repo
-git clone -b $COSMOS_SDK_VERSION --depth 1 https://github.com/cosmos/cosmos-sdk.git ./tmp-swagger-gen/cosmos-sdk
+if [ ! -d ./tmp-swagger-gen/cosmos-sdk ]; then
+    git clone -b $COSMOS_SDK_VERSION --depth 1 https://github.com/cosmos/cosmos-sdk.git ./tmp-swagger-gen/cosmos-sdk
+fi
+trap "rm -rf ./tmp-swagger-gen" EXIT
 
 # generate openapi
-pushd ./tmp-swagger-gen/cosmos-sdk
-../../scripts/swagger/protoc-swagger-gen.sh $CONFIG_FILE $OUTPUT_FILE
-popd
-
-rm -rf ./tmp-swagger-gen
+pushd ./tmp-swagger-gen/cosmos-sdk || exit
+../../scripts/swagger/protoc-swagger-gen.sh "$CONFIG_FILE" "$OUTPUT_FILE"
+popd || exit

--- a/scripts/cosmos-swagger-gen.sh
+++ b/scripts/cosmos-swagger-gen.sh
@@ -13,6 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -o pipefail
+set -o errexit
+set -o nounset
+if [[ "${DEBUG:-false}" == "true" ]]; then
+    set -o xtrace
+fi
+
 TYPE=${1:-tx}
 valid_values=(base tx)
 if ! printf '%s\0' "${valid_values[@]}" | grep -qxFe "$TYPE"; then

--- a/scripts/dcl-swagger-gen.sh
+++ b/scripts/dcl-swagger-gen.sh
@@ -1,7 +1,20 @@
 #!/usr/bin/env bash
+# Copyright 2022
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 echo "Generating DCL openapi ..."
 CONFIG_FILE="$PWD/scripts/swagger/config/dcl-config.json"
 OUTPUT_FILE="$PWD/docs/static/openapi.yml"
 
-./scripts/swagger/protoc-swagger-gen.sh $CONFIG_FILE $OUTPUT_FILE
+./scripts/swagger/protoc-swagger-gen.sh "$CONFIG_FILE" "$OUTPUT_FILE"


### PR DESCRIPTION
The container image created from the `scripts/Dockerfile` results in `1.81GB` size, it's not following some Docker best practices(e.g. [multistage builds](https://docs.docker.com/develop/develop-images/multistage-build/)) and installing unnecessary packages. These changes reduce the size of the image to `1.03GB`.

This new image has been validated with [Hadolint tool](https://github.com/hadolint/hadolint).

> Note: This PR also modifies another `Dockerfiles` fixing linting issues as well as creates a GitHub Workflow to validate future changes.