### PR TITLE
DCL binary install script

### DIFF
--- a/deployment/scripts/install.sh
+++ b/deployment/scripts/install.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Copyright 2022 Samsung Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o nounset
+set -o errexit
+set -o pipefail
+if [[ "${DEBUG:-false}" == "true" ]]; then
+    set -o xtrace
+fi
+
+function info {
+    _print_msg "INFO" "$1"
+}
+
+function warn {
+    _print_msg "WARN" "$1"
+}
+
+function _print_msg {
+    echo "$(date +%H:%M:%S) - $1: $2"
+}
+
+function get_github_latest_release {
+    version=""
+    attempt_counter=0
+    max_attempts=5
+
+    until [ "$version" ]; do
+        url_effective=$(curl -sL -o /dev/null -w '%{url_effective}' "https://github.com/$1/releases/latest")
+        if [ "$url_effective" ]; then
+            version="${url_effective##*/}"
+            break
+        elif [ ${attempt_counter} -eq ${max_attempts} ];then
+            echo "Max attempts reached"
+            exit 1
+        fi
+        attempt_counter=$((attempt_counter+1))
+        sleep $((attempt_counter*2))
+    done
+    echo "${version#v}"
+}
+
+function main {
+    readonly dcl_home=${DCL_HOME:-"$HOME/.dcl"}
+    local version=${VERSION:-$(get_github_latest_release zigbee-alliance/distributed-compliance-ledger)}
+    local dest=${DEST:-"$dcl_home/cosmovisor/upgrades/v$version/bin"}
+
+    if [ ! -f "$dest/dcld" ] || [[ "$("$dest/dcld" version)" != "$version" ]]; then
+        info "Installing DCL client $version version..."
+
+        distro="macos"
+        if [ "$(uname)" == "Linux" ]; then
+            # shellcheck disable=SC1091
+            source /etc/os-release || source /usr/lib/os-release
+            distro="${ID,,}"
+        fi
+
+        info "Downloading the DCL binary for $distro..."
+        mkdir -p "$dest"
+        url="https://github.com/zigbee-alliance/distributed-compliance-ledger/releases/download/v$version/dcld.$distro.tar.gz"
+        if command -v wget > /dev/null; then
+            wget -q -c "$url" -O - | sudo tar -xz -C "$dest"
+        elif command -v curl > /dev/null; then
+            curl -s "$url" | sudo tar -xz -C "$dest"
+        fi
+
+        sudo chown -R "$(whoami)" "$dcl_home"
+        sudo chmod a+x "$dest/dcld"
+    fi
+
+    if [ -n "${SHA256SUM:-}" ] && command -v sha256sum > /dev/null; then
+        info "Validating $SHA256SUM checksum..."
+        sha256sum --check --quiet <(echo "${SHA256SUM} $dest/dcld")
+    else
+        warn "Checksum wasn't performed"
+    fi
+}
+
+main

--- a/deployment/scripts/install.sh
+++ b/deployment/scripts/install.sh
@@ -28,6 +28,11 @@ function warn {
     _print_msg "WARN" "$1"
 }
 
+function error {
+    _print_msg "ERROR" "$1"
+    exit 1
+}
+
 function _print_msg {
     echo "$(date +%H:%M:%S) - $1: $2"
 }
@@ -87,5 +92,22 @@ function main {
         warn "Checksum wasn't performed"
     fi
 }
+
+# Validators
+info "Validating $USER permissions"
+if ! sudo -n "true"; then
+    error "passwordless sudo is needed for '$(whoami)' user."
+fi
+
+info "Validating cosmovisor service"
+if ! systemctl is-active --quiet cosmovisor; then
+    error "cosmovisor service is not active"
+fi
+
+info "Validating cosmovisor user"
+# shellcheck disable=SC2009
+if [[ "$(whoami)" != "$(ps -o comm,user | grep cosmovisor | awk '{print $2}')" ]]; then
+    error "This script needs to be executed with comovisor user"
+fi
 
 main

--- a/docs/pool-upgrade-how-to.md
+++ b/docs/pool-upgrade-how-to.md
@@ -118,49 +118,23 @@ application version:
        dcld query upgrade plan
        ```
 
-    3. Verifies that the downloaded application binary matches the checksum
-       specified in the URL. This can be done automatically together with the
-       previous step by [`go-getter`](https://github.com/hashicorp/go-getter)
-       download tool (its executable binaries for various platforms can be
-       downloaded from <https://github.com/hashicorp/go-getter/releases>).
+    3. Downloads and verifies that the downloaded application binary matches
+       the checksum specified in the URL. This can be done with a single-line
+       command:
 
        For example:
 
        ```bash
-       go-getter https://github.com/zigbee-alliance/distributed-compliance-ledger/releases/download/vX.X.X/dcld?checksum=sha256:50708d4f7e00da347d4e678bf26780cd424232461c4bb414f72391c75e39545a $HOME/Downloads
+       curl -fsSL https://raw.githubusercontent.com/zigbee-alliance/distributed-compliance-ledger/master/deployment/scripts/install.sh | SHA256SUM=ea0e16eed3cc30b5a7f17299aca01b5d827b9a04576662d957af02608bca0fb6 bash
        ```
 
-       `go-getter` verifies that the downloaded file matches the checksum when
-       the URL is provided in the specified format. If the downloaded file
-       checksum does not equal to the checksum provided in the URL, `go-getter`
-       reports that checksums did not match.
-
-    4. Creates a directory with the name of the upgrade within
-       `$HOME/.dcl/cosmovisor/upgrades`, creates `bin` sub-directory within the
-       created directory, and puts the new application binary into `bin`
-       sub-directory.
-
-       For example:
-
-       ```bash
-       cd $HOME/.dcl/cosmovisor
-       mkdir -p upgrades
-       cd upgrades
-       mkdir vX.X.X
-       cd vX.X.X
-       mkdir bin
-       cd $HOME/Downloads
-       cp ./dcld $HOME/.dcl/cosmovisor/upgrades/vX.X.X/bin/
-       ```
-
-    5. Sets proper owner and permissions for the new application binary.
-
-       For example:
-
-       ```bash
-       sudo chown $(whoami) $HOME/.dcl/cosmovisor/upgrades/vX.X.X/bin/dcld
-       sudo chmod a+x $HOME/.dcl/cosmovisor/upgrades/vX.X.X/bin/dcld
-       ```
+       | Variable   | Default                                     | Description                                  |
+       |:-----------|:--------------------------------------------|----------------------------------------------|
+       | DEBUG      | false                                       | Enables verbose mode during the execution    |
+       | DCL_HOME   | $HOME/.dcl                                  | DCL home folder                              |
+       | VERSION    |                                             | DCL binary version to be upgraded            |
+       | DEST       | $DCL_HOME/cosmovisor/upgrades/v$VERSION/bin | Destination path for DCL binary              |
+       | SHA256SUM  |                                             | SHA256 sum value for DCL binary verification |
 
 7. **Upgrade Is Applied**: The upgrade is applied on all the nodes in the pool
    when the ledger reaches the height specified in the upgrade plan.


### PR DESCRIPTION
Having a script that automates the DCL binary installation process can reduce time during the upgrade process and minimize the deployment errors. This PR offers an installation script to perform the installation and verification of DCL binary.