### PR TITLE
Disable golangci-lint new linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,3 +46,6 @@ linters:
     - gci
     - containedctx
     - maintidx
+    - execinquery
+    - nonamedreturns
+    - exhaustruct

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -257,7 +258,7 @@ func newNetwork(t *testing.T, cfg Config) *Network {
 
 			apiURL, err := url.Parse(apiListenAddr)
 			require.NoError(t, err)
-			apiAddr = fmt.Sprintf("http://%s:%s", apiURL.Hostname(), apiURL.Port())
+			apiAddr = "http://" + net.JoinHostPort(apiURL.Hostname(), apiURL.Port())
 
 			rpcAddr, _, err := server.FreeTCPAddr()
 			require.NoError(t, err)


### PR DESCRIPTION
The latest `golangci-lint` [release](https://github.com/golangci/golangci-lint/releases) include several new [linters](https://golangci-lint.run/usage/linters/) which causes issues on the CI.

This change disables some of them and fixes an issue reported by `nosprintfhostport` linter.