### PR TITLE
Update default version to 0.11.0 for bootstrap role

### DIFF
--- a/deployment/ansible/roles/bootstrap/defaults/main.yml
+++ b/deployment/ansible/roles/bootstrap/defaults/main.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 dcl_home: /var/lib/dcl/.dcl
-dcl_version: 0.10.0
+dcl_version: 0.11.0
 dcld:
   version: "{{ dcl_version }}"
   path: "{{ dcl_home }}/cosmovisor/genesis/bin/dcld"
@@ -27,12 +27,14 @@ cosmovisor:
   home: "{{ dcl_home | dirname }}"
 
 dcld_checksums:
+  0.11.0: 33986b277be76d3e7b5443a09232d87d58324ad7cb6123f3d550149f2dc28452
   0.10.0: ea0e16eed3cc30b5a7f17299aca01b5d827b9a04576662d957af02608bca0fb6
   0.9.0: c333d828a124e527dd7a9c0170f77d61ad07091d9f6cd61dd0175a36b55aadce
   0.8.0: eae8e20cbe7c9fc1e090aa8ab358afdf2044636911d75c2284f733e33f0acaab
   0.7.0: 50708d4f7e00da347d4e678bf26780cd424232461c4bb414f72391c75e39545a
   0.6.0: 1ab6b9084fc0444858307f13b708d9f275d548dd2cfb3bc7d8e10d59897d7278
 cosmovisor_checksums:
+  0.11.0: 05bf568e34a7c92a61f268401a9f1d6df3c3f015e884a239da5d35c299da6adb
   0.10.0: 6dac8f0e0267bd930be91c6f3369eb9c35a649546ea071b223a7c8c00203d26a
   0.9.0: c05705efe5369b9d83e65ef7b252bd7c610eec414ae3f6c08681bcf49dc38e6d
   0.8.0: c05705efe5369b9d83e65ef7b252bd7c610eec414ae3f6c08681bcf49dc38e6d

--- a/deployment/test-requirements.txt
+++ b/deployment/test-requirements.txt
@@ -4,32 +4,34 @@
 #
 #    pip-compile --output-file=test-requirements.txt test-requirements.in
 #
-ansible==5.7.1
+ansible==5.8.0
     # via -r test-requirements.in
-ansible-compat==2.0.3
+ansible-compat==2.1.0
     # via
     #   ansible-lint
     #   molecule
     #   molecule-docker
-ansible-core==2.12.5
+ansible-core==2.12.6
     # via
     #   ansible
     #   ansible-lint
-ansible-lint==6.0.2
+ansible-lint==6.2.1
     # via -r test-requirements.in
 arrow==1.2.2
     # via jinja2-time
 attrs==21.4.0
-    # via pytest
+    # via
+    #   jsonschema
+    #   pytest
 bcrypt==3.2.2
     # via paramiko
 binaryornot==0.4.4
     # via cookiecutter
-bracex==2.2.1
+bracex==2.3
     # via wcmatch
 cerberus==1.3.2
     # via molecule
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via requests
 cffi==1.15.0
     # via
@@ -65,6 +67,8 @@ enrich==1.2.7
     #   molecule
 idna==3.3
     # via requests
+importlib-resources==5.7.1
+    # via jsonschema
 iniconfig==1.1.1
     # via pytest
 jinja2==3.1.2
@@ -77,6 +81,10 @@ jinja2-time==0.2.0
     # via cookiecutter
 jmespath==1.0.0
     # via -r test-requirements.in
+jsonschema==4.5.1
+    # via
+    #   ansible-compat
+    #   ansible-lint
 markupsafe==2.1.1
     # via jinja2
 molecule==3.6.1
@@ -93,7 +101,7 @@ packaging==21.3
     #   ansible-lint
     #   molecule
     #   pytest
-paramiko==2.10.4
+paramiko==2.11.0
     # via molecule
 pathspec==0.9.0
     # via yamllint
@@ -111,10 +119,14 @@ pygments==2.12.0
     # via rich
 pynacl==1.5.0
     # via paramiko
-pyparsing==3.0.8
+pyparsing==3.0.9
     # via packaging
+pyrsistent==0.18.1
+    # via jsonschema
 pytest==7.1.2
-    # via pytest-testinfra
+    # via
+    #   ansible-lint
+    #   pytest-testinfra
 pytest-testinfra==6.7.0
     # via -r test-requirements.in
 python-dateutil==2.8.2
@@ -135,7 +147,7 @@ requests==2.27.1
     #   molecule-docker
 resolvelib==0.5.4
     # via ansible-core
-rich==12.4.1
+rich==12.4.4
     # via
     #   ansible-lint
     #   enrich
@@ -171,6 +183,8 @@ yamllint==1.26.3
     # via
     #   -r test-requirements.in
     #   ansible-lint
+zipp==3.8.0
+    # via importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
The default version used by the `bootstrap` role was updated with the latest release. It's also updated the python requirements file used by the molecule unit tests.