### PR TITLE
add new validation mothod for validate binaries

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -104,6 +104,8 @@ jobs:
           set -euo pipefail
           # shellcheck disable=SC2046
           go test -json -v $(go list ./... | grep -v '/integration_tests') 2>&1 | tee /tmp/gotest.log | gotestfmt
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
   integration-tests:
     if: needs.changes.outputs.src == 'true'
     name: Integration tests
@@ -126,6 +128,8 @@ jobs:
       - name: Run integration tests
         shell: bash
         run: integration_tests/run-all.sh
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
   lint:
     if: needs.changes.outputs.go == 'true'
     name: Check linter issues with golangci-lint tool

--- a/integration_tests/cli/common.sh
+++ b/integration_tests/cli/common.sh
@@ -105,6 +105,26 @@ response_does_not_contain() {
     echo "${GREEN}SUCCESS: ${RESET}Result does not contain unexpected substring: '$_unexpected_string'"
 }
 
+check_upgrade_plan_info () {
+    local _result="$1"
+    local _expected_upgrade_plan_info="$2"
+    local _info=$(echo "$_result" | jq '.plan.info')
+
+    if [[ "$_info" == "null" ]]; then
+        _info=$(echo "$_result" | jq '.info')
+    fi
+
+    _info=${_info//\\/}
+
+    if [[ "$_info" != "\"$_expected_upgrade_plan_info\"" ]]; then
+        echo "$_info != $_expected_upgrade_plan_info"
+        echo "ERROR: command failed. The expected upgrade plan info: '$_expected_upgrade_plan_info' not found in the result: $_result"
+        exit 1
+    fi
+
+    echo "${GREEN}SUCCESS: ${RESET} Result contains upgrade plan info: '$_expected_upgrade_plan_info'"
+}
+
 create_new_account(){
   local __resultvar="$1"
   random_string name

--- a/integration_tests/cli/upgrade-demo.sh
+++ b/integration_tests/cli/upgrade-demo.sh
@@ -17,79 +17,90 @@ set -euo pipefail
 source integration_tests/cli/common.sh
 
 upgrade_height=$(($RANDOM + 10000000))
-random_string upgrade_info
+
+upgrade_plan_name_v1_2_0="v1.2.0"
+upgrade_plan_info_v1_2_0="{\"binaries\":{\"linux/amd64\":\"https://github.com/zigbee-alliance/distributed-compliance-ledger/releases/download/v1.2.0/dcld?checksum=sha256:e4031c6a77aa8e58add391be671a334613271bcf6e7f11d23b04a0881ece6958\"}}"
+upgrade_plan_name_v1_2_1="v1.2.1"
+upgrade_plan_info_v1_2_1="{\"binaries\":{\"linux/amd64\":\"https://github.com/zigbee-alliance/distributed-compliance-ledger/releases/download/v1.2.1/dcld?checksum=sha256:e4031c6a77aa8e58add391be671a334613271bcf6e7f11d23b04a0881ece6958\"}}"
+
+upgrade_plan_name_v1_2_2="v1.2.2"
+upgrade_plan_info_v1_2_2="{\"binaries\":{\"linux/amd64\":\"https://github.com/zigbee-alliance/distributed-compliance-ledger/releases/download/v1.2.2/dcld?checksum=sha256:e4031c6a77aa8e58add391be671a334613271bcf6e7f11d23b04a0881ece6958\"}}"
+upgrade_plan_name_v1_4_0="v1.4.0"
+upgrade_plan_info_v1_4_0="{\"binaries\":{\"linux/amd64\":\"https://github.com/zigbee-alliance/distributed-compliance-ledger/releases/download/v1.4.0/dcld?checksum=sha256:e4031c6a77aa8e58add391be671a334613271bcf6e7f11d23b04a0881ece6958\"}}"
+upgrade_plan_name_v1_4_1="v1.4.1"
+upgrade_plan_info_v1_4_1="{\"binaries\":{\"linux/amd64\":\"https://github.com/zigbee-alliance/distributed-compliance-ledger/releases/download/v1.4.1/dcld?checksum=sha256:e4031c6a77aa8e58add391be671a334613271bcf6e7f11d23b04a0881ece6958\"}}"
 
 echo "propose and approve upgrade"
 echo "Create Trustee account"
 create_new_account trustee_account "Trustee"
-random_string upgrade_name
-propose=$(dcld tx dclupgrade propose-upgrade --name=$upgrade_name --upgrade-height=$upgrade_height --upgrade-info=$upgrade_info --from $trustee_account --yes)
+
+propose=$(dcld tx dclupgrade propose-upgrade --name=$upgrade_plan_name_v1_2_0 --upgrade-height=$upgrade_height --upgrade-info=$upgrade_plan_info_v1_2_0 --from $trustee_account --yes)
 propose=$(get_txn_result "$propose")
 echo "propose upgrade response: $propose"
 check_response "$propose" "\"code\": 0"
 
-proposed_dclupgrade_query=$(dcld query dclupgrade proposed-upgrade --name=$upgrade_name)
+proposed_dclupgrade_query=$(dcld query dclupgrade proposed-upgrade --name=$upgrade_plan_name_v1_2_0)
 echo "dclupgrade proposed upgrade query: $proposed_dclupgrade_query"
-check_response_and_report "$proposed_dclupgrade_query" "\"name\": \"$upgrade_name\""
+check_response_and_report "$proposed_dclupgrade_query" "\"name\": \"$upgrade_plan_name_v1_2_0\""
 check_response_and_report "$proposed_dclupgrade_query" "\"height\": \"$upgrade_height\""
-check_response_and_report "$proposed_dclupgrade_query" "\"info\": \"$upgrade_info\""
+check_upgrade_plan_info "$proposed_dclupgrade_query" "$upgrade_plan_info_v1_2_0"
 
-approve=$(dcld tx dclupgrade approve-upgrade --name=$upgrade_name --from alice --yes)
+approve=$(dcld tx dclupgrade approve-upgrade --name=$upgrade_plan_name_v1_2_0 --from alice --yes)
 approve=$(get_txn_result "$approve")
 echo "approve upgrade response: $approve"
 check_response "$approve" "\"code\": 0"
 
-reject=$(dcld tx dclupgrade reject-upgrade --name=$upgrade_name --from alice --yes)
+reject=$(dcld tx dclupgrade reject-upgrade --name=$upgrade_plan_name_v1_2_0 --from alice --yes)
 reject=$(get_txn_result "$reject")
 echo "reject upgrade response: $reject"
 check_response "$reject" "\"code\": 0"
 
-approve=$(dcld tx dclupgrade approve-upgrade --name=$upgrade_name --from alice --yes)
+approve=$(dcld tx dclupgrade approve-upgrade --name=$upgrade_plan_name_v1_2_0 --from alice --yes)
 approve=$(get_txn_result "$approve")
 echo "approve upgrade response: $approve"
 check_response "$approve" "\"code\": 0"
 
-proposed_dclupgrade_query=$(dcld query dclupgrade proposed-upgrade --name=$upgrade_name)
+proposed_dclupgrade_query=$(dcld query dclupgrade proposed-upgrade --name=$upgrade_plan_name_v1_2_0)
 echo "dclupgrade proposed upgrade query: $proposed_dclupgrade_query"
-check_response_and_report "$proposed_dclupgrade_query" "\"name\": \"$upgrade_name\""
+check_response_and_report "$proposed_dclupgrade_query" "\"name\": \"$upgrade_plan_name_v1_2_0\""
 check_response_and_report "$proposed_dclupgrade_query" "\"height\": \"$upgrade_height\""
-check_response_and_report "$proposed_dclupgrade_query" "\"info\": \"$upgrade_info\""
+check_upgrade_plan_info "$proposed_dclupgrade_query" "$upgrade_plan_info_v1_2_0"
 
-approved_dclupgrade_query=$(dcld query dclupgrade approved-upgrade --name=$upgrade_name)
+approved_dclupgrade_query=$(dcld query dclupgrade approved-upgrade --name=$upgrade_plan_name_v1_2_0)
 echo "dclupgrade approved upgrade query: $approved_dclupgrade_query"
 check_response "$approved_dclupgrade_query" "Not Found"
 
 plan_query=$(dcld query upgrade plan 2>&1) || true
 check_response "$plan_query" "no upgrade scheduled" raw
 
-approve=$(dcld tx dclupgrade approve-upgrade --name=$upgrade_name --from bob --yes)
+approve=$(dcld tx dclupgrade approve-upgrade --name=$upgrade_plan_name_v1_2_0 --from bob --yes)
 approve=$(get_txn_result "$approve")
 echo "approve upgrade response: $approve"
 check_response "$approve" "\"code\": 0"
 
 plan_query=$(dcld query upgrade plan)
 echo "plan query: $plan_query"
-check_response_and_report "$plan_query" "\"name\": \"$upgrade_name\""
+check_response_and_report "$plan_query" "\"name\": \"$upgrade_plan_name_v1_2_0\""
 check_response_and_report "$plan_query" "\"height\": \"$upgrade_height\""
-check_response_and_report "$plan_query" "\"info\": \"$upgrade_info\""
+check_upgrade_plan_info "$plan_query" "$upgrade_plan_info_v1_2_0"
 
-approved_dclupgrade_query=$(dcld query dclupgrade approved-upgrade --name=$upgrade_name)
+approved_dclupgrade_query=$(dcld query dclupgrade approved-upgrade --name=$upgrade_plan_name_v1_2_0)
 echo "dclupgrade approved upgrade query: $approved_dclupgrade_query"
-check_response "$approved_dclupgrade_query" "\"name\": \"$upgrade_name\""
+check_response "$approved_dclupgrade_query" "\"name\": \"$upgrade_plan_name_v1_2_0\""
 check_response "$approved_dclupgrade_query" "\"height\": \"$upgrade_height\""
-check_response "$approved_dclupgrade_query" "\"info\": \"$upgrade_info\""
+check_upgrade_plan_info "$approved_dclupgrade_query" "$upgrade_plan_info_v1_2_0"
 
-proposed_dclupgrade_query=$(dcld query dclupgrade proposed-upgrade --name=$upgrade_name)
+proposed_dclupgrade_query=$(dcld query dclupgrade proposed-upgrade --name=$upgrade_plan_name_v1_2_0)
 echo "dclupgrade proposed upgrade query: $proposed_dclupgrade_query"
 check_response "$proposed_dclupgrade_query" "Not Found" raw
 
 
 test_divider
 
+random_string upgrade_name
 
 echo "proposer cannot approve upgrade"
-random_string upgrade_name
-propose=$(dcld tx dclupgrade propose-upgrade --name=$upgrade_name --upgrade-height=$upgrade_height --upgrade-info=$upgrade_info --from alice --yes)
+propose=$(dcld tx dclupgrade propose-upgrade --name=$upgrade_name --upgrade-height=$upgrade_height --from alice --yes)
 propose=$(get_txn_result "$propose")
 echo "propose upgrade response: $propose"
 check_response "$propose" "\"code\": 0"
@@ -102,10 +113,9 @@ check_response_and_report "$approve" "unauthorized" raw
 
 test_divider
 
-
-echo "cannot approve upgrade twice"
 random_string upgrade_name
-propose=$(dcld tx dclupgrade propose-upgrade --name=$upgrade_name --upgrade-height=$upgrade_height --upgrade-info=$upgrade_info --from alice --yes)
+echo "cannot approve upgrade twice"
+propose=$(dcld tx dclupgrade propose-upgrade --name=$upgrade_name --upgrade-height=$upgrade_height --from alice --yes)
 propose=$(get_txn_result "$propose")
 echo "propose upgrade response: $propose"
 check_response "$propose" "\"code\": 0"
@@ -122,15 +132,14 @@ check_response_and_report "$second_approve" "unauthorized" raw
 
 test_divider
 
-
-echo "cannot propose upgrade twice"
 random_string upgrade_name
-propose=$(dcld tx dclupgrade propose-upgrade --name=$upgrade_name --upgrade-height=$upgrade_height --upgrade-info=$upgrade_info --from alice --yes)
+echo "cannot propose upgrade twice"
+propose=$(dcld tx dclupgrade propose-upgrade --name=$upgrade_name --upgrade-height=$upgrade_height --from alice --yes)
 propose=$(get_txn_result "$propose")
 echo "propose upgrade response: $propose"
 check_response "$propose" "\"code\": 0"
 
-second_propose=$(dcld tx dclupgrade propose-upgrade --name=$upgrade_name --upgrade-height=$upgrade_height --upgrade-info=$upgrade_info --from alice --yes)
+second_propose=$(dcld tx dclupgrade propose-upgrade --name=$upgrade_name --upgrade-height=$upgrade_height --from alice --yes)
 second_propose=$(get_txn_result "$second_propose")
 echo "second propose upgrade response: $second_propose"
 check_response_and_report "$second_propose" "proposed upgrade already exists" raw
@@ -138,11 +147,10 @@ check_response_and_report "$second_propose" "proposed upgrade already exists" ra
 
 test_divider
 
-
-echo "upgrade height < current height"
 random_string upgrade_name
+echo "upgrade height < current height"
 height=1
-propose=$(dcld tx dclupgrade propose-upgrade --name=$upgrade_name --upgrade-height=$height --upgrade-info=$upgrade_info --from alice --yes)
+propose=$(dcld tx dclupgrade propose-upgrade --name=$upgrade_name --upgrade-height=$height --from alice --yes)
 propose=$(get_txn_result "$propose")
 echo "propose upgrade response: $propose"
 check_response_and_report "$propose" "upgrade cannot be scheduled in the past" raw
@@ -150,115 +158,76 @@ check_response_and_report "$propose" "upgrade cannot be scheduled in the past" r
 
 test_divider
 
-upgrade_height=$(($RANDOM + 10000000))
-random_string upgrade_info
-
 echo "propose and reject upgrade"
-random_string upgrade_name
-propose=$(dcld tx dclupgrade propose-upgrade --name=$upgrade_name --upgrade-height=$upgrade_height --upgrade-info=$upgrade_info --from $trustee_account --yes)
+upgrade_height=$(($RANDOM + 10000000))
+propose=$(dcld tx dclupgrade propose-upgrade --name=$upgrade_plan_name_v1_2_1 --upgrade-height=$upgrade_height --upgrade-info=$upgrade_plan_info_v1_2_1 --from $trustee_account --yes)
 propose=$(get_txn_result "$propose")
 echo "propose upgrade response: $propose"
 check_response "$propose" "\"code\": 0"
 
-test_divider
-
-approve=$(dcld tx dclupgrade approve-upgrade --name=$upgrade_name --from alice --yes)
+approve=$(dcld tx dclupgrade approve-upgrade --name=$upgrade_plan_name_v1_2_1 --from alice --yes)
 approve=$(get_txn_result "$approve")
 echo "approve upgrade response: $approve"
 check_response "$approve" "\"code\": 0"
 
-test_divider
-
-proposed_dclupgrade_query=$(dcld query dclupgrade proposed-upgrade --name=$upgrade_name)
+proposed_dclupgrade_query=$(dcld query dclupgrade proposed-upgrade --name=$upgrade_plan_name_v1_2_1)
 echo "dclupgrade proposed upgrade query: $proposed_dclupgrade_query"
-check_response_and_report "$proposed_dclupgrade_query" "\"name\": \"$upgrade_name\""
+check_response_and_report "$proposed_dclupgrade_query" "\"name\": \"$upgrade_plan_name_v1_2_1\""
 check_response_and_report "$proposed_dclupgrade_query" "\"height\": \"$upgrade_height\""
-check_response_and_report "$proposed_dclupgrade_query" "\"info\": \"$upgrade_info\""
+check_upgrade_plan_info "$proposed_dclupgrade_query" "$upgrade_plan_info_v1_2_1"
 
-test_divider
-
-reject=$(dcld tx dclupgrade reject-upgrade --name=$upgrade_name --from $trustee_account --yes)
+reject=$(dcld tx dclupgrade reject-upgrade --name=$upgrade_plan_name_v1_2_1 --from $trustee_account --yes)
 reject=$(get_txn_result "$reject")
 echo "reject upgrade response: $reject"
 check_response "$reject" "\"code\": 0"
 
-test_divider
-
-approve=$(dcld tx dclupgrade approve-upgrade --name=$upgrade_name --from $trustee_account --yes)
+approve=$(dcld tx dclupgrade approve-upgrade --name=$upgrade_plan_name_v1_2_1 --from $trustee_account --yes)
 approve=$(get_txn_result "$approve")
 echo "approve upgrade response: $approve"
 check_response "$approve" "\"code\": 0"
 
-test_divider
-
-reject=$(dcld tx dclupgrade reject-upgrade --name=$upgrade_name --from alice --yes)
+reject=$(dcld tx dclupgrade reject-upgrade --name=$upgrade_plan_name_v1_2_1 --from alice --yes)
 reject=$(get_txn_result "$reject")
 echo "reject upgrade response: $reject"
 check_response "$reject" "\"code\": 0"
 
-test_divider
+# second_reject=$(dcld tx dclupgrade reject-upgrade ---name=$upgrade_plan_name_v1_2_1 --from alice --yes)
+# second_reject=$(get_txn_result "$second_reject")
+# echo "second_reject upgrade response: $reject"
+# response_does_not_contain "$second_reject" "\"code\": 0"
 
-second_reject=$(dcld tx dclupgrade reject-upgrade --name=$upgrade_name --from alice --yes)
-second_reject=$(get_txn_result "$second_reject")
-echo "second_reject upgrade response: $reject"
-response_does_not_contain "$second_reject" "\"code\": 0"
-
-test_divider
-
-proposed_dclupgrade_query=$(dcld query dclupgrade proposed-upgrade --name=$upgrade_name)
+proposed_dclupgrade_query=$(dcld query dclupgrade proposed-upgrade --name=$upgrade_plan_name_v1_2_1)
 echo "dclupgrade proposed upgrade query: $proposed_dclupgrade_query"
-check_response_and_report "$proposed_dclupgrade_query" "\"name\": \"$upgrade_name\""
+check_response_and_report "$proposed_dclupgrade_query" "\"name\": \"$upgrade_plan_name_v1_2_1\""
 check_response_and_report "$proposed_dclupgrade_query" "\"height\": \"$upgrade_height\""
-check_response_and_report "$proposed_dclupgrade_query" "\"info\": \"$upgrade_info\""
+check_upgrade_plan_info "$proposed_dclupgrade_query" "$upgrade_plan_info_v1_2_1"
 
-test_divider
-
-proposed_dclupgrade_query=$(dcld query dclupgrade proposed-upgrade --name=$upgrade_name)
-echo "dclupgrade proposed upgrade query: $proposed_dclupgrade_query"
-check_response_and_report "$proposed_dclupgrade_query" "\"name\": \"$upgrade_name\""
-check_response_and_report "$proposed_dclupgrade_query" "\"height\": \"$upgrade_height\""
-check_response_and_report "$proposed_dclupgrade_query" "\"info\": \"$upgrade_info\""
-
-test_divider
-
-rejected_dclupgrade_query=$(dcld query dclupgrade rejected-upgrade --name=$upgrade_name)
+rejected_dclupgrade_query=$(dcld query dclupgrade rejected-upgrade --name=$upgrade_plan_name_v1_2_1)
 echo "dclupgrade rejected upgrade query: $rejected_dclupgrade_query"
 check_response "$rejected_dclupgrade_query" "Not Found"
 
-test_divider
-
-approved_dclupgrade_query=$(dcld query dclupgrade approved-upgrade --name=$upgrade_name)
+approved_dclupgrade_query=$(dcld query dclupgrade approved-upgrade --name=$upgrade_plan_name_v1_2_1)
 echo "dclupgrade approved upgrade query: $approved_dclupgrade_query"
 check_response "$approved_dclupgrade_query" "Not Found"
 
-test_divider
-
-reject=$(dcld tx dclupgrade reject-upgrade --name=$upgrade_name --from bob --yes)
+reject=$(dcld tx dclupgrade reject-upgrade --name=$upgrade_plan_name_v1_2_1 --from bob --yes)
 reject=$(get_txn_result "$reject")
 echo "reject upgrade response: $reject"
 check_response "$reject" "\"code\": 0"
 
-test_divider
-
-rejected_dclupgrade_query=$(dcld query dclupgrade rejected-upgrade --name=$upgrade_name)
+rejected_dclupgrade_query=$(dcld query dclupgrade rejected-upgrade --name=$upgrade_plan_name_v1_2_1)
 echo "dclupgrade rejected upgrade query: $rejected_dclupgrade_query"
-check_response_and_report "$rejected_dclupgrade_query" "\"name\": \"$upgrade_name\""
+check_response_and_report "$rejected_dclupgrade_query" "\"name\": \"$upgrade_plan_name_v1_2_1\""
 check_response_and_report "$rejected_dclupgrade_query" "\"height\": \"$upgrade_height\""
-check_response_and_report "$rejected_dclupgrade_query" "\"info\": \"$upgrade_info\""
+check_upgrade_plan_info "$rejected_dclupgrade_query" "$upgrade_plan_info_v1_2_1"
 
-test_divider
-
-proposed_dclupgrade_query=$(dcld query dclupgrade proposed-upgrade --name=$upgrade_name)
+proposed_dclupgrade_query=$(dcld query dclupgrade proposed-upgrade --name=$upgrade_plan_name_v1_2_1)
 echo "dclupgrade rejected upgrade query: $proposed_dclupgrade_query"
 check_response "$proposed_dclupgrade_query" "Not Found"
 
-test_divider
-
-approved_dclupgrade_query=$(dcld query dclupgrade approved-upgrade --name=$upgrade_name)
+approved_dclupgrade_query=$(dcld query dclupgrade approved-upgrade --name=$upgrade_plan_name_v1_2_1)
 echo "dclupgrade rejected upgrade query: $approved_dclupgrade_query"
 check_response "$approved_dclupgrade_query" "Not Found"
-
-test_divider
 
 # APPROVE UPGRADE'S PLAN HEIGHT LESS THAN BLOCK HEIGHT AND RE-PROPOSE UPGRADE PLAN HEIGHT BIGGER THAN BLOCK HEIGHT
 ###########################################################################################################################################
@@ -266,27 +235,25 @@ get_height current_height
 echo "Current height is $current_height"
 plan_height=$(expr $current_height + 3)
 echo "$plan_height"
-random_string upgrade_name
-random_string upgrade_info
 
 echo "propose upgrade's plan height bigger than block height"
-propose=$(dcld tx dclupgrade propose-upgrade --name=$upgrade_name --upgrade-height=$plan_height --upgrade-info=$upgrade_info --from jack --yes)
+propose=$(dcld tx dclupgrade propose-upgrade --name=$upgrade_plan_name_v1_2_2 --upgrade-height=$plan_height --upgrade-info=$upgrade_plan_info_v1_2_2 --from jack --yes)
 propose=$(get_txn_result "$propose")
 echo "propose upgrade response: $propose"
 check_response "$propose" "\"code\": 0"
 
-proposed_dclupgrade_query=$(dcld query dclupgrade proposed-upgrade --name=$upgrade_name)
+proposed_dclupgrade_query=$(dcld query dclupgrade proposed-upgrade --name=$upgrade_plan_name_v1_2_2)
 echo "dclupgrade proposed upgrade query: $proposed_dclupgrade_query"
-check_response_and_report "$proposed_dclupgrade_query" "\"name\": \"$upgrade_name\""
+check_response_and_report "$proposed_dclupgrade_query" "\"name\": \"$upgrade_plan_name_v1_2_2\""
 check_response_and_report "$proposed_dclupgrade_query" "\"height\": \"$plan_height\""
-check_response_and_report "$proposed_dclupgrade_query" "\"info\": \"$upgrade_info\""
+check_upgrade_plan_info "$proposed_dclupgrade_query" "$upgrade_plan_info_v1_2_2"
 
 wait_for_height $(expr $plan_height + 5) 300 outage-safe
 get_height current_height
 echo "Current height is $current_height"
 
 echo "approve upgrade's plan height less than block height"
-approve=$(dcld tx dclupgrade approve-upgrade --name=$upgrade_name --from alice --yes)
+approve=$(dcld tx dclupgrade approve-upgrade --name=$upgrade_plan_name_v1_2_2 --from alice --yes)
 approve=$(get_txn_result "$approve")
 echo "approve upgrade response: $approve"
 check_response_and_report "$approve" "upgrade cannot be scheduled in the past" raw
@@ -296,16 +263,16 @@ echo "Current height is $current_height"
 plan_height=$(expr $current_height + 3)
 
 echo "re-propose upgrade's plan height bigger than block height"
-propose=$(dcld tx dclupgrade propose-upgrade --name=$upgrade_name --upgrade-height=$plan_height --upgrade-info=$upgrade_info --from jack --yes)
+propose=$(dcld tx dclupgrade propose-upgrade --name=$upgrade_plan_name_v1_2_2 --upgrade-height=$plan_height --upgrade-info=$upgrade_plan_info_v1_2_2 --from jack --yes)
 propose=$(get_txn_result "$propose")
 echo "propose upgrade response: $propose"
 check_response "$propose" "\"code\": 0"
 
-proposed_dclupgrade_query=$(dcld query dclupgrade proposed-upgrade --name=$upgrade_name)
+proposed_dclupgrade_query=$(dcld query dclupgrade proposed-upgrade --name=$upgrade_plan_name_v1_2_2)
 echo "dclupgrade proposed upgrade query: $proposed_dclupgrade_query"
-check_response_and_report "$proposed_dclupgrade_query" "\"name\": \"$upgrade_name\""
+check_response_and_report "$proposed_dclupgrade_query" "\"name\": \"$upgrade_plan_name_v1_2_2\""
 check_response_and_report "$proposed_dclupgrade_query" "\"height\": \"$plan_height\""
-check_response_and_report "$proposed_dclupgrade_query" "\"info\": \"$upgrade_info\""
+check_upgrade_plan_info "$proposed_dclupgrade_query" "$upgrade_plan_info_v1_2_2"
 ###########################################################################################################################################
 
 test_divider
@@ -315,33 +282,31 @@ test_divider
 get_height current_height
 echo "Current height is $current_height"
 plan_height=$(expr $current_height + 3)
-random_string upgrade_name
-random_string upgrade_info
 
 echo "propose upgrade's plan height bigger than block height"
-propose=$(dcld tx dclupgrade propose-upgrade --name=$upgrade_name --upgrade-height=$plan_height --upgrade-info=$upgrade_info --from jack --yes)
+propose=$(dcld tx dclupgrade propose-upgrade --name=$upgrade_plan_name_v1_4_0 --upgrade-height=$plan_height --upgrade-info=$upgrade_plan_info_v1_4_0 --from jack --yes)
 propose=$(get_txn_result "$propose")
 echo "propose upgrade response: $propose"
 check_response "$propose" "\"code\": 0"
 
-proposed_dclupgrade_query=$(dcld query dclupgrade proposed-upgrade --name=$upgrade_name)
+proposed_dclupgrade_query=$(dcld query dclupgrade proposed-upgrade --name=$upgrade_plan_name_v1_4_0)
 echo "dclupgrade proposed upgrade query: $proposed_dclupgrade_query"
-check_response_and_report "$proposed_dclupgrade_query" "\"name\": \"$upgrade_name\""
+check_response_and_report "$proposed_dclupgrade_query" "\"name\": \"$upgrade_plan_name_v1_4_0\""
 check_response_and_report "$proposed_dclupgrade_query" "\"height\": \"$plan_height\""
-check_response_and_report "$proposed_dclupgrade_query" "\"info\": \"$upgrade_info\""
+check_upgrade_plan_info "$proposed_dclupgrade_query" "$upgrade_plan_info_v1_4_0"
 
 wait_for_height $(expr $plan_height + 5) 300 outage-safe
 get_height current_height
 echo "Current height is $current_height"
 
 echo "approve upgrade's plan height less than block height"
-approve=$(dcld tx dclupgrade approve-upgrade --name=$upgrade_name --from alice --yes)
+approve=$(dcld tx dclupgrade approve-upgrade --name=$upgrade_plan_name_v1_4_0 --from alice --yes)
 approve=$(get_txn_result "$approve")
 echo "approve upgrade response: $approve"
 check_response_and_report "$approve" "upgrade cannot be scheduled in the past" raw
 
 echo "re-propose upgrade's plan height bigger than block height"
-propose=$(dcld tx dclupgrade propose-upgrade --name=$upgrade_name --upgrade-height=$plan_height --upgrade-info=$upgrade_info --from jack --yes)
+propose=$(dcld tx dclupgrade propose-upgrade --name=$upgrade_plan_name_v1_4_0 --upgrade-height=$plan_height --upgrade-info=$upgrade_plan_info_v1_4_0 --from jack --yes)
 propose=$(get_txn_result "$propose")
 echo "propose upgrade response: $propose"
 check_response_and_report "$propose" "upgrade cannot be scheduled in the past" raw
@@ -351,41 +316,39 @@ test_divider
 get_height current_height
 echo "Current height is $current_height"
 plan_height=$(expr $current_height + 3)
-random_string upgrade_name
-random_string upgrade_info
 
 # 18. TEST PROPOSE AND REJECT UPGRADE
 echo "18. TEST PROPOSE AND REJECT UPGRADE"
 test_divider
 
 echo "jack (Trustee) propose upgrade"
-result=$(dcld tx dclupgrade propose-upgrade --name=$upgrade_name --upgrade-height=$plan_height --upgrade-info=$upgrade_info --from jack --yes)
+result=$(dcld tx dclupgrade propose-upgrade --name=$upgrade_plan_name_v1_4_1 --upgrade-height=$plan_height --upgrade-info=$upgrade_plan_info_v1_4_1 --from jack --yes)
 result=$(get_txn_result "$result")
 check_response "$result" "\"code\": 0"
 
 echo "jack (Trustee) rejects upgrade"
-result=$(dcld tx dclupgrade reject-upgrade --name=$upgrade_name --from jack --yes)
+result=$(dcld tx dclupgrade reject-upgrade --name=$upgrade_plan_name_v1_4_1 --from jack --yes)
 result=$(get_txn_result "$result")
 check_response "$result" "\"code\": 0"
 
 test_divider
 
 echo "Upgrade not found in proposed upgrade"
-result=$(dcld query dclupgrade proposed-upgrade --name=$upgrade_name)
+result=$(dcld query dclupgrade proposed-upgrade --name=$upgrade_plan_name_v1_4_1)
 echo $result | jq
 check_response "$result" "Not Found"
 
 test_divider
 
 echo "Upgrade not found in rejected upgrade"
-result=$(dcld query dclupgrade rejected-upgrade --name=$upgrade_name)
+result=$(dcld query dclupgrade rejected-upgrade --name=$upgrade_plan_name_v1_4_1)
 echo $result | jq
 check_response "$result" "Not Found"
 
 test_divider
 
 echo "Upgrade not found in approved upgrade query"
-result=$(dcld query dclupgrade approved-upgrade --name=$upgrade_name)
+result=$(dcld query dclupgrade approved-upgrade --name=$upgrade_plan_name_v1_4_1)
 echo $result | jq
 check_response "$result" "Not Found"
 

--- a/integration_tests/constants/constants.go
+++ b/integration_tests/constants/constants.go
@@ -137,10 +137,24 @@ var (
 	TestDate   = "2020-02-02T02:00:00Z"
 
 	// Upgrade.
-	UpgradePlanName         = "TestUpgrade"
-	UpgradePlanHeight int64 = 1337
-	UpgradePlanInfo         = "Some upgrade info"
+	UpgradePlanNameV1_2_0 = "v1.2.0"
+	UpgradePlanInfoV1_2_0 = "{\"binaries\":{\"linux/amd64\":\"https://github.com/zigbee-alliance/distributed-compliance-ledger/releases/download/v1.2.0/dcld?checksum=sha256:e4031c6a77aa8e58add391be671a334613271bcf6e7f11d23b04a0881ece6958\"}}"
+	UpgradePlanNameV1_2_1 = "v1.2.1"
+	UpgradePlanInfoV1_2_1 = "{\"binaries\":{\"linux/amd64\":\"https://github.com/zigbee-alliance/distributed-compliance-ledger/releases/download/v1.2.1/dcld?checksum=sha256:e4031c6a77aa8e58add391be671a334613271bcf6e7f11d23b04a0881ece6958\"}}"
+	UpgradePlanNameV1_2_2 = "v1.2.2"
+	UpgradePlanInfoV1_2_2 = "{\"binaries\":{\"linux/amd64\":\"https://github.com/zigbee-alliance/distributed-compliance-ledger/releases/download/v1.2.2/dcld?checksum=sha256:e4031c6a77aa8e58add391be671a334613271bcf6e7f11d23b04a0881ece6958\"}}"
+	UpgradePlanNameV1_4_0 = "v1.4.0"
+	UpgradePlanInfoV1_4_0 = "{\"binaries\":{\"linux/amd64\":\"https://github.com/zigbee-alliance/distributed-compliance-ledger/releases/download/v1.4.0/dcld?checksum=sha256:e4031c6a77aa8e58add391be671a334613271bcf6e7f11d23b04a0881ece6958\"}}"
+	UpgradePlanNameV1_4_1 = "v1.4.1"
+	UpgradePlanInfoV1_4_1 = "{\"binaries\":{\"linux/amd64\":\"https://github.com/zigbee-alliance/distributed-compliance-ledger/releases/download/v1.4.1/dcld?checksum=sha256:e4031c6a77aa8e58add391be671a334613271bcf6e7f11d23b04a0881ece6958\"}}"
+	UpgradePlanNameV1_4_2 = "v1.4.2"
+	UpgradePlanInfoV1_4_2 = "{\"binaries\":{\"linux/amd64\":\"https://github.com/zigbee-alliance/distributed-compliance-ledger/releases/download/v1.4.2/dcld?checksum=sha256:e4031c6a77aa8e58add391be671a334613271bcf6e7f11d23b04a0881ece6958\"}}"
 
+	UpgradePlanName                 = "v1.4.4"
+	UpgradePlanHeight         int64 = 1337
+	UpgradePlanInfo                 = "{\"binaries\":{\"linux/amd64\":\"https://github.com/zigbee-alliance/distributed-compliance-ledger/releases/download/v1.4.4/dcld?checksum=sha256:e4031c6a77aa8e58add391be671a334613271bcf6e7f11d23b04a0881ece6958\"}}"
+	UpgradeBrowserDownloadURL       = "https://github.com/zigbee-alliance/distributed-compliance-ledger/releases/download/v1.4.4/dcld"
+	UpgradeGitAPIJSONResponse       = "{\"assets\":[{\"name\": \"dcld\", \"state\": \"uploaded\", \"digest\": \"sha256:e4031c6a77aa8e58add391be671a334613271bcf6e7f11d23b04a0881ece6958\", \"browser_download_url\":\"" + UpgradeBrowserDownloadURL + "\"}]}"
 	//
 	Address1, _           = sdk.AccAddressFromBech32("cosmos1s5xf3aanx7w84hgplk9z3l90qfpantg6nsmhpf")
 	Address2, _           = sdk.AccAddressFromBech32("cosmos1nl4uaesk9gtu7su3n89lne6xpa6lq8gljn79rq")

--- a/integration_tests/grpc_rest/dclupgrade/helpers.go
+++ b/integration_tests/grpc_rest/dclupgrade/helpers.go
@@ -276,7 +276,7 @@ func Demo(suite *utils.TestSuite) {
 	require.NoError(suite.T, err)
 
 	// trustee proposes upgrade
-	proposeUpgradeMsg := NewMsgProposeUpgrade(aliceAccount.Address, utils.RandString(), 100000, utils.RandString())
+	proposeUpgradeMsg := NewMsgProposeUpgrade(aliceAccount.Address, testconstants.UpgradePlanNameV1_2_0, 100000, testconstants.UpgradePlanInfoV1_2_0)
 	_, err = suite.BuildAndBroadcastTx([]sdk.Msg{proposeUpgradeMsg}, aliceName, aliceAccount)
 	require.NoError(suite.T, err)
 
@@ -340,7 +340,7 @@ func Demo(suite *utils.TestSuite) {
 	require.Contains(suite.T, approvedUpgrades, *approvedUpgrade)
 
 	// Trustee proposes upgrade
-	proposeUpgradeMsg = NewMsgProposeUpgrade(aliceAccount.Address, utils.RandString(), 100000, utils.RandString())
+	proposeUpgradeMsg = NewMsgProposeUpgrade(aliceAccount.Address, testconstants.UpgradePlanNameV1_2_1, 100000, testconstants.UpgradePlanInfoV1_2_1)
 	_, err = suite.BuildAndBroadcastTx([]sdk.Msg{proposeUpgradeMsg}, aliceName, aliceAccount)
 	require.NoError(suite.T, err)
 
@@ -465,7 +465,7 @@ func ProposeUpgradeByNonTrustee(suite *utils.TestSuite) {
 	)
 
 	// try to add proposeUpgradeMsg
-	proposeUpgradeMsg := NewMsgProposeUpgrade(nonTrusteeAccount.Address, utils.RandString(), 100000, utils.RandString())
+	proposeUpgradeMsg := NewMsgProposeUpgrade(nonTrusteeAccount.Address, testconstants.UpgradePlanNameV1_2_2, 100000, testconstants.UpgradePlanInfoV1_2_2)
 	_, err = suite.BuildAndBroadcastTx([]sdk.Msg{proposeUpgradeMsg}, nonTrusteeAccountName, nonTrusteeAccount)
 	require.Error(suite.T, err)
 	require.ErrorIs(suite.T, err, sdkerrors.ErrUnauthorized)
@@ -490,7 +490,7 @@ func ApproveUpgradeByNonTrustee(suite *utils.TestSuite) {
 	require.NoError(suite.T, err)
 
 	// propose upgrade
-	proposeUpgradeMsg := NewMsgProposeUpgrade(aliceAccount.Address, utils.RandString(), 100000, utils.RandString())
+	proposeUpgradeMsg := NewMsgProposeUpgrade(aliceAccount.Address, testconstants.UpgradePlanNameV1_4_0, 100000, testconstants.UpgradePlanInfoV1_4_0)
 	_, err = suite.BuildAndBroadcastTx([]sdk.Msg{proposeUpgradeMsg}, aliceName, aliceAccount)
 	require.NoError(suite.T, err)
 
@@ -538,10 +538,8 @@ func ProposeUpgradeTwice(suite *utils.TestSuite) {
 	bobAccount, err := test_dclauth.GetAccount(suite, address)
 	require.NoError(suite.T, err)
 
-	planName, height, info := utils.RandString(), int64(100000), utils.RandString()
-
 	// trustee proposes upgrade
-	proposeUpgradeMsg := NewMsgProposeUpgrade(aliceAccount.Address, planName, height, info)
+	proposeUpgradeMsg := NewMsgProposeUpgrade(aliceAccount.Address, testconstants.UpgradePlanNameV1_4_1, 100000, testconstants.UpgradePlanInfoV1_4_1)
 	_, err = suite.BuildAndBroadcastTx([]sdk.Msg{proposeUpgradeMsg}, aliceName, aliceAccount)
 	require.NoError(suite.T, err)
 
@@ -552,7 +550,7 @@ func ProposeUpgradeTwice(suite *utils.TestSuite) {
 	require.ErrorIs(suite.T, err, dclupgradetypes.ErrProposedUpgradeAlreadyExists)
 
 	// trustee rejects upgrade
-	rejectUpgradeMsg := NewMsgRejectUpgrade(aliceAccount.Address, planName)
+	rejectUpgradeMsg := NewMsgRejectUpgrade(aliceAccount.Address, testconstants.UpgradePlanNameV1_4_1)
 	_, err = suite.BuildAndBroadcastTx([]sdk.Msg{rejectUpgradeMsg}, aliceName, aliceAccount)
 	require.NoError(suite.T, err)
 }
@@ -567,15 +565,13 @@ func ProposeAndRejectUpgrade(suite *utils.TestSuite) {
 	aliceAccount, err := test_dclauth.GetAccount(suite, address)
 	require.NoError(suite.T, err)
 
-	planName, height, info := utils.RandString(), int64(100000), utils.RandString()
-
 	// trustee proposes upgrade
-	proposeUpgradeMsg := NewMsgProposeUpgrade(aliceAccount.Address, planName, height, info)
+	proposeUpgradeMsg := NewMsgProposeUpgrade(aliceAccount.Address, testconstants.UpgradePlanNameV1_4_2, 100000, testconstants.UpgradePlanInfoV1_4_2)
 	_, err = suite.BuildAndBroadcastTx([]sdk.Msg{proposeUpgradeMsg}, aliceName, aliceAccount)
 	require.NoError(suite.T, err)
 
 	// trustee rejects upgrade
-	rejectUpgradeMsg := NewMsgRejectUpgrade(aliceAccount.Address, planName)
+	rejectUpgradeMsg := NewMsgRejectUpgrade(aliceAccount.Address, testconstants.UpgradePlanNameV1_4_2)
 	_, err = suite.BuildAndBroadcastTx([]sdk.Msg{rejectUpgradeMsg}, aliceName, aliceAccount)
 	require.NoError(suite.T, err)
 

--- a/integration_tests/start-pool.sh
+++ b/integration_tests/start-pool.sh
@@ -1,5 +1,6 @@
 source integration_tests/cli/common.sh
 
+DCLD_VERSION=${1:-""}
 LOCALNET_DIR=".localnet"
 SED_EXT=
 
@@ -17,7 +18,14 @@ patch_consensus_config() {
   done
 }
 
-make install image localnet_rebuild
+if [ -n "$DCLD_VERSION" ]; then
+  make image localnet_clean
+  /bin/bash ./genlocalnetconfig.sh "$DCLD_VERSION"
+  /bin/bash ./genlocalnetappbins.sh "" "" "" "$DCLD_VERSION"
+else
+  make install image localnet_rebuild
+fi
+
 patch_consensus_config
 make localnet_start
 wait_for_height 2 20

--- a/x/dclupgrade/client/cli/tx_propose_upgrade.go
+++ b/x/dclupgrade/client/cli/tx_propose_upgrade.go
@@ -35,8 +35,13 @@ func CmdProposeUpgrade() *cobra.Command {
 				info,
 			)
 
-			// validate basic will be called in GenerateOrBroadcastTxCLI
-			err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			err = msg.ValidateBasicCLI()
+
+			if err == nil {
+				// validate basic will be called in GenerateOrBroadcastTxCLI
+				err = tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+			}
+
 			if cli.IsWriteInsteadReadRPCError(err) {
 				return clientCtx.PrintString(cli.LightClientProxyForWriteRequests)
 			}

--- a/x/dclupgrade/types/message_propose_upgrade.go
+++ b/x/dclupgrade/types/message_propose_upgrade.go
@@ -1,6 +1,12 @@
 package types
 
 import (
+	context "context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strings"
 	"time"
 
 	"cosmossdk.io/errors"
@@ -10,6 +16,7 @@ import (
 )
 
 const TypeMsgProposeUpgrade = "propose_upgrade"
+const GitReleaseAPIURL = "https://api.github.com/repos/zigbee-alliance/distributed-compliance-ledger/releases/tags"
 
 var _ sdk.Msg = &MsgProposeUpgrade{}
 
@@ -45,6 +52,112 @@ func (msg *MsgProposeUpgrade) GetSignBytes() []byte {
 	return sdk.MustSortJSON(bz)
 }
 
+func ValidateBinaries(msg *MsgProposeUpgrade, gitBaseURL string) error {
+	if len(msg.Plan.Info) == 0 {
+		return nil
+	}
+
+	var planInfoJSON map[string]map[string]string
+
+	err := json.Unmarshal([]byte(msg.Plan.Info), &planInfoJSON)
+	if err != nil {
+		return errors.Wrapf(sdkerrors.ErrJSONUnmarshal, "failed to unmarshal upgrade plan info: %v", err)
+	}
+
+	binariesLen := len(planInfoJSON["binaries"])
+
+	if binariesLen > 1 {
+		return errors.Wrapf(sdkerrors.ErrJSONUnmarshal, "supports only one binary file")
+	}
+
+	if binariesLen == 0 {
+		return errors.Wrapf(sdkerrors.ErrJSONUnmarshal, "binary files not found")
+	}
+
+	for osName, urlWithSum := range planInfoJSON["binaries"] {
+		if osName != "linux/amd64" {
+			return errors.Wrapf(sdkerrors.ErrJSONUnmarshal, "supports only \"linux/amd64\" binary files")
+		}
+
+		fileURL, sha256Sum, foundSep := strings.Cut(urlWithSum, "?")
+		if !foundSep || !strings.HasPrefix(sha256Sum, "checksum=") {
+			return errors.Wrapf(sdkerrors.ErrJSONUnmarshal, "failed to parse upgrade plan URL")
+		}
+
+		sha256Sum = strings.TrimPrefix(sha256Sum, "checksum=")
+
+		partsURL := strings.Split(fileURL, "/")
+
+		if len(partsURL) <= 7 {
+			return errors.Wrapf(sdkerrors.ErrInvalidRequest, "unexpected binary URL format: %s", fileURL)
+		}
+
+		urlGitTag := partsURL[7]
+
+		if msg.Plan.Name != urlGitTag {
+			return errors.Wrapf(sdkerrors.ErrInvalidRequest, "planName is not equal to the binary file version")
+		}
+
+		ctx := context.Background()
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, gitBaseURL+"/"+urlGitTag, http.NoBody)
+		if err != nil {
+			return errors.Wrapf(sdkerrors.ErrInvalidRequest, "binary file info create request failed")
+		}
+
+		gitToken := os.Getenv("GH_TOKEN")
+		if len(gitToken) > 0 {
+			req.Header.Add("Authorization", "token "+gitToken)
+		}
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+
+		if err != nil {
+			return errors.Wrapf(sdkerrors.ErrInvalidRequest, "binary file info do request failed")
+		}
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Wrapf(sdkerrors.ErrInvalidRequest, "binary file info request failed")
+		}
+
+		var parsedBody map[string]any
+
+		err = json.Unmarshal(body, &parsedBody)
+		if err != nil {
+			return errors.Wrapf(sdkerrors.ErrJSONUnmarshal, "failed to parse binary file info")
+		}
+
+		assets, assetsExist := parsedBody["assets"]
+
+		if !assetsExist {
+			return errors.Wrapf(sdkerrors.ErrJSONUnmarshal, "invalid assets in json response")
+		}
+
+		valid := false
+
+		for _, asset := range assets.([]any) {
+			assetMap := asset.(map[string]any)
+
+			if assetMap["name"] == "dcld" &&
+				assetMap["state"] == "uploaded" &&
+				assetMap["browser_download_url"] == fileURL &&
+				(assetMap["digest"] == nil || assetMap["digest"] == sha256Sum) {
+				valid = true
+
+				break
+			}
+		}
+
+		if !valid {
+			return errors.Wrapf(sdkerrors.ErrInvalidRequest, "invalid binary file")
+		}
+	}
+
+	return nil
+}
+
 func (msg *MsgProposeUpgrade) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
@@ -57,6 +170,30 @@ func (msg *MsgProposeUpgrade) ValidateBasic() error {
 	}
 
 	err = msg.Plan.ValidateBasic()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (msg *MsgProposeUpgrade) ValidateBasicCLI() error {
+	_, err := sdk.AccAddressFromBech32(msg.Creator)
+	if err != nil {
+		return errors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+	}
+
+	err = validator.Validate(msg)
+	if err != nil {
+		return err
+	}
+
+	err = msg.Plan.ValidateBasic()
+	if err != nil {
+		return err
+	}
+
+	err = ValidateBinaries(msg, GitReleaseAPIURL)
 	if err != nil {
 		return err
 	}

--- a/x/dclupgrade/types/message_propose_upgrade_test.go
+++ b/x/dclupgrade/types/message_propose_upgrade_test.go
@@ -3,6 +3,10 @@ package types
 import (
 	"testing"
 
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 	testconstants "github.com/zigbee-alliance/distributed-compliance-ledger/integration_tests/constants"
@@ -154,6 +158,164 @@ func TestMsgProposeUpgrade_ValidateBasic(t *testing.T) {
 	for _, tt := range negativeTests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.msg.ValidateBasic()
+			require.Error(t, err)
+			require.ErrorIs(t, err, tt.err)
+		})
+	}
+}
+
+func TestMsgProposeUpgrade_ValidateBinaries(t *testing.T) {
+	var expectedResponse string
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, expectedResponse)
+	}))
+	defer svr.Close()
+
+	negativeTests := []struct {
+		name     string
+		expected string
+		msg      MsgProposeUpgrade
+		err      error
+	}{
+		{
+			name:     "invalid binary format 1",
+			expected: testconstants.UpgradeGitAPIJSONResponse,
+			msg: MsgProposeUpgrade{
+				Creator: sample.AccAddress(),
+				Plan: Plan{
+					Name:   testconstants.UpgradePlanName,
+					Height: testconstants.UpgradePlanHeight,
+					Info:   "{\"binaries\":{\"linux/amd64\":\"https://github.com/zigbee-alliance/distributed-compliance-ledger/releases/download/v1.4.4/dcld-checksum=sha256:e4031c6a77aa8e58add391be671a334613271bcf6e7f11d23b04a0881ece6958\"}}",
+				},
+				Info: testconstants.Info,
+				Time: testconstants.Time,
+			},
+			err: sdkerrors.ErrJSONUnmarshal,
+		},
+		{
+			name:     "invalid binary format 2",
+			expected: testconstants.UpgradeGitAPIJSONResponse,
+			msg: MsgProposeUpgrade{
+				Creator: sample.AccAddress(),
+				Plan: Plan{
+					Name:   testconstants.UpgradePlanName,
+					Height: testconstants.UpgradePlanHeight,
+					Info:   "{\"binaries\":{\"linux/amd64\":\"https://github.com/zigbee-alliance/distributed-compliance-ledger/releases/download/v1.4.4/dcld?checksum-sha256:e4031c6a77aa8e58add391be671a334613271bcf6e7f11d23b04a0881ece6958\"}}",
+				},
+				Info: testconstants.Info,
+				Time: testconstants.Time,
+			},
+			err: sdkerrors.ErrJSONUnmarshal,
+		},
+		{
+			name:     "invalid binary format 3",
+			expected: testconstants.UpgradeGitAPIJSONResponse,
+			msg: MsgProposeUpgrade{
+				Creator: sample.AccAddress(),
+				Plan: Plan{
+					Name:   testconstants.UpgradePlanName,
+					Height: testconstants.UpgradePlanHeight,
+					Info:   "{\"binaries\":[\"linux/amd64\":\"https://github.com/zigbee-alliance/distributed-compliance-ledger/releases/download/v1.4.4/dcld?checksum-sha256:e4031c6a77aa8e58add391be671a334613271bcf6e7f11d23b04a0881ece6958\"]}",
+				},
+				Info: testconstants.Info,
+				Time: testconstants.Time,
+			},
+			err: sdkerrors.ErrJSONUnmarshal,
+		},
+		{
+			name:     "lots of binary files",
+			expected: testconstants.UpgradeGitAPIJSONResponse,
+			msg: MsgProposeUpgrade{
+				Creator: sample.AccAddress(),
+				Plan: Plan{
+					Name:   testconstants.UpgradePlanName,
+					Height: testconstants.UpgradePlanHeight,
+					Info:   "{\"binaries\":{\"linux/amd64\":\"URL1\", \"mac\":\"URL2\"}}",
+				},
+				Info: testconstants.Info,
+				Time: testconstants.Time,
+			},
+			err: sdkerrors.ErrJSONUnmarshal,
+		},
+		{
+			name:     "unsupported os platform",
+			expected: testconstants.UpgradeGitAPIJSONResponse,
+			msg: MsgProposeUpgrade{
+				Creator: sample.AccAddress(),
+				Plan: Plan{
+					Name:   testconstants.UpgradePlanName,
+					Height: testconstants.UpgradePlanHeight,
+					Info:   "{\"binaries\":[\"mac\":\"https://github.com/zigbee-alliance/distributed-compliance-ledger/releases/download/v1.4.4/dcld?checksum-sha256:e4031c6a77aa8e58add391be671a334613271bcf6e7f11d23b04a0881ece6958\"]}",
+				},
+				Info: testconstants.Info,
+				Time: testconstants.Time,
+			},
+			err: sdkerrors.ErrJSONUnmarshal,
+		},
+		{
+			name:     "no binary files",
+			expected: testconstants.UpgradeGitAPIJSONResponse,
+			msg: MsgProposeUpgrade{
+				Creator: sample.AccAddress(),
+				Plan: Plan{
+					Name:   testconstants.UpgradePlanName,
+					Height: testconstants.UpgradePlanHeight,
+					Info:   "{\"binaries\":{}}",
+				},
+				Info: testconstants.Info,
+				Time: testconstants.Time,
+			},
+			err: sdkerrors.ErrJSONUnmarshal,
+		},
+	}
+
+	positiveTests := []struct {
+		name     string
+		expected string
+		msg      MsgProposeUpgrade
+	}{
+		{
+			name:     "valid binary file without checksum",
+			expected: "{\"assets\":[{\"name\": \"dcld\", \"state\": \"uploaded\", \"digest\": null, \"browser_download_url\":\"" + testconstants.UpgradeBrowserDownloadURL + "\"}]}",
+			msg: MsgProposeUpgrade{
+				Creator: sample.AccAddress(),
+				Plan: Plan{
+					Name:   testconstants.UpgradePlanName,
+					Height: testconstants.UpgradePlanHeight,
+					Info:   testconstants.UpgradePlanInfo,
+				},
+				Info: testconstants.Info,
+				Time: testconstants.Time,
+			},
+		},
+		{
+			name:     "valid binary file with checksum",
+			expected: testconstants.UpgradeGitAPIJSONResponse,
+			msg: MsgProposeUpgrade{
+				Creator: sample.AccAddress(),
+				Plan: Plan{
+					Name:   testconstants.UpgradePlanName,
+					Height: testconstants.UpgradePlanHeight,
+					Info:   testconstants.UpgradePlanInfo,
+				},
+				Info: testconstants.Info,
+				Time: testconstants.Time,
+			},
+		},
+	}
+	for _, tt := range positiveTests {
+		t.Run(tt.name, func(t *testing.T) {
+			expectedResponse = tt.expected
+			err := ValidateBinaries(&tt.msg, svr.URL)
+			require.NoError(t, err)
+		})
+	}
+
+	for _, tt := range negativeTests {
+		t.Run(tt.name, func(t *testing.T) {
+			expectedResponse = tt.expected
+			err := ValidateBinaries(&tt.msg, svr.URL)
 			require.Error(t, err)
 			require.ErrorIs(t, err, tt.err)
 		})


### PR DESCRIPTION
**The Issue to solve:**
UpgradeProposal with incorrect upgrade_plan is sent and approved (incorrect means it doesn't match the constant from app.go, upgrade handler name)
Upgrade starts, and as upgrade_plan is wrong, the dcld cannot start

**Complications:**
the handler that is required exists only in the new version, as it performs specific migrations after update
there is no way to find out about its existence before the update, unless you look at the source code

**How to solve:**
Add validation in `.github/workflows/release.yml`:
do not build a release if in the `app.go` is missing a handler with a corresponding name (do not apply to dev release)
an example for the  v1.4.3 version from git:  `app.UpgradeKeeper.SetUpgradeHandler("v1.4.3", `

Add validation in `message_propose_upgrade.go:ValidateBasic()`:
- if the upgrade_plan does not match the dcld version on git (git tag) - validation error
- if the dcld file does not exist - validation error
- if the checksum differs from the specified one (if any) - validation error
Then the upgrade shouldn't be scheduled.

**Main points:**
- Each release version has its own upgrade handler with the corresponding name. This ensures that the update handler is available by version name.
- _Propose upgrade_ checks for theavailability of the file, update name, etc. in the release version. This ensures that the file is available and its version matches the plan name.

**Worry:**
- is it good to do dynamic validation with static validation? (`message_propose_upgrade.go:ValidateBasic()` has a simple static validations, we add a http request to the git resource)
- If validation happens on multiple nodes in different ways, what will happen? (It should be checked, it's probably not dangerous)
- the [release md](https://github.com/zigbee-alliance/distributed-compliance-ledger/blob/master/docs/release.md) states that we use release_tag=binary_version, which is not quite the case in practice. We plan to use this hard matching.
