### PR TITLE
GCP support for terraform driven infrastructure

### DIFF
--- a/deployment/terraform/gcp/iam/main.tf
+++ b/deployment/terraform/gcp/iam/main.tf
@@ -1,0 +1,24 @@
+resource "google_service_account" "default" {
+  account_id   = "dcl-node"
+  display_name = "DCL Node Service Account"
+}
+
+// TODO: Review and adjust assigned roles
+
+resource "google_project_iam_member" "logging" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.default.email}"
+}
+
+resource "google_project_iam_member" "monitoring" {
+  project = var.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.default.email}"
+}
+
+resource "google_project_iam_member" "login" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountUser"
+  member  = "serviceAccount:${google_service_account.default.email}"
+}

--- a/deployment/terraform/gcp/iam/outputs.tf
+++ b/deployment/terraform/gcp/iam/outputs.tf
@@ -1,0 +1,4 @@
+output "service_account_email" {
+  description = "Service account email"
+  value       = google_service_account.default.email
+}

--- a/deployment/terraform/gcp/iam/provider.tf
+++ b/deployment/terraform/gcp/iam/provider.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      // TODO: Initially set the same as AWS one. What should be here?
+      version = ">= 4.1"
+    }
+  }
+}

--- a/deployment/terraform/gcp/iam/variables.tf
+++ b/deployment/terraform/gcp/iam/variables.tf
@@ -1,0 +1,4 @@
+variable "project_id" {
+  description = "The GCP project ID"
+  type        = string
+}

--- a/deployment/terraform/gcp/locals.tf
+++ b/deployment/terraform/gcp/locals.tf
@@ -1,0 +1,105 @@
+locals {
+
+  project_name_default = "DCL"
+
+  base_labels = {
+    project     = local.project_name_default
+    environment = terraform.workspace
+  }
+
+  disable_validator_protection = var.disable_validator_protection
+
+  labels = merge(local.base_labels, { for k, v in var.common_labels : k => v if try(length(v), 0) > 0 })
+
+  nodes = {
+    validator = {
+      private_ips = module.validator.private_ips
+      public_ips  = module.validator.public_ips
+    }
+
+    private_sentries = {
+      private_ips = var.private_sentries_config.enable ? module.private_sentries[0].private_ips : []
+      public_ips  = var.private_sentries_config.enable ? module.private_sentries[0].public_ips : []
+    }
+
+    public_sentries = {
+      private_ips = concat(
+        (var.private_sentries_config.enable && var.public_sentries_config.enable && contains(var.public_sentries_config.regions, 1)) ? module.public_sentries_1[0].private_ips : [],
+        (var.private_sentries_config.enable && var.public_sentries_config.enable && contains(var.public_sentries_config.regions, 2)) ? module.public_sentries_2[0].private_ips : [],
+      )
+
+      public_ips = concat(
+        (var.private_sentries_config.enable && var.public_sentries_config.enable && contains(var.public_sentries_config.regions, 1)) ? module.public_sentries_1[0].public_ips : [],
+        (var.private_sentries_config.enable && var.public_sentries_config.enable && contains(var.public_sentries_config.regions, 2)) ? module.public_sentries_2[0].public_ips : [],
+      )
+    }
+
+    seeds = {
+      private_ips = concat(
+        (var.private_sentries_config.enable && var.public_sentries_config.enable && contains(var.public_sentries_config.regions, 1)) ? module.public_sentries_1[0].seed_private_ips : [],
+        (var.private_sentries_config.enable && var.public_sentries_config.enable && contains(var.public_sentries_config.regions, 2)) ? module.public_sentries_2[0].seed_private_ips : [],
+      )
+
+      public_ips = concat(
+        (var.private_sentries_config.enable && var.public_sentries_config.enable && contains(var.public_sentries_config.regions, 1)) ? module.public_sentries_1[0].seed_public_ips : [],
+        (var.private_sentries_config.enable && var.public_sentries_config.enable && contains(var.public_sentries_config.regions, 2)) ? module.public_sentries_2[0].seed_public_ips : [],
+      )
+    }
+
+    observers = {
+      private_ips = concat(
+        (var.private_sentries_config.enable && var.observers_config.enable && contains(var.observers_config.regions, 1)) ? module.observers_1[0].private_ips : [],
+        (var.private_sentries_config.enable && var.observers_config.enable && contains(var.observers_config.regions, 2)) ? module.observers_2[0].private_ips : [],
+      )
+
+      public_ips = concat(
+        (var.private_sentries_config.enable && var.observers_config.enable && contains(var.observers_config.regions, 1)) ? module.observers_1[0].public_ips : [],
+        (var.private_sentries_config.enable && var.observers_config.enable && contains(var.observers_config.regions, 2)) ? module.observers_2[0].public_ips : [],
+      )
+    }
+  }
+
+  ansible_inventory = {
+    all = {
+      children = {
+        genesis = {
+          hosts = var.validator_config.is_genesis ? { for host in local.nodes.validator.public_ips : host => null } : null
+        }
+
+        validators = {
+          hosts = { for host in local.nodes.validator.public_ips : host => null }
+        }
+
+        private_sentries = {
+          hosts = { for host in local.nodes.private_sentries.public_ips : host => null }
+        }
+
+        public_sentries = {
+          hosts = { for host in local.nodes.public_sentries.public_ips : host => null }
+        }
+
+        seeds = {
+          hosts = { for host in local.nodes.seeds.public_ips : host => null }
+        }
+
+        observers = {
+          hosts = { for host in local.nodes.observers.public_ips : host => null }
+        }
+      }
+    }
+  }
+
+  prometheus_endpoints = concat(
+    local.nodes.validator.private_ips,
+    local.nodes.private_sentries.private_ips,
+    local.nodes.public_sentries.private_ips,
+    local.nodes.observers.private_ips,
+    local.nodes.seeds.private_ips
+  )
+
+  prometheus_enabled = var.private_sentries_config.enable && var.prometheus_config.enable
+
+  prometheus_endpoint = local.prometheus_enabled ? module.prometheus[0].prometheus_endpoint : null
+
+  default_source_image = "ubuntu-os-pro-cloud/ubuntu-minimal-pro-2004-lts"
+}

--- a/deployment/terraform/gcp/main.tf
+++ b/deployment/terraform/gcp/main.tf
@@ -1,0 +1,198 @@
+provider "google" {
+  alias   = "region_1"
+  region  = var.region_1
+  project = var.project_id
+}
+
+provider "google" {
+  alias   = "region_2"
+  region  = var.region_2
+  project = var.project_id
+}
+
+# Enable OS Login for all compute instances in the project
+resource "google_compute_project_metadata" "default" {
+  metadata = {
+    enable-oslogin = "TRUE"
+  }
+}
+
+# IAM
+module "iam" {
+  source = "./iam"
+  providers = {
+    google = google.region_1
+  }
+  project_id = var.project_id
+}
+
+# Validator
+module "validator" {
+  source = "./validator"
+  providers = {
+    google = google.region_1
+  }
+
+  labels = local.labels
+
+  instance_type = var.validator_config.instance_type
+  disable_instance_protection = local.disable_validator_protection
+  service_account_email = module.iam.service_account_email
+
+  boot_image = local.default_source_image
+  subnetwork = ""
+  project_id = var.project_id
+}
+
+# Private Sentries
+module "private_sentries" {
+  count = var.private_sentries_config.enable ? 1 : 0
+
+  source = "./private-sentries"
+  providers = {
+    google      = google.region_1
+    google.peer = google.region_1
+  }
+
+  labels = local.labels
+
+  nodes_count           = var.private_sentries_config.nodes_count
+  instance_type         = var.private_sentries_config.instance_type
+  service_account_email = module.iam.service_account_email
+
+  ssh_public_key_path  = var.ssh_public_key_path
+  ssh_private_key_path = var.ssh_private_key_path
+
+  peer_vpc = module.validator.vpc
+  project_id = var.project_id
+  region = var.region_1
+}
+
+# Public Sentries region 1
+module "public_sentries_1" {
+  count = (var.private_sentries_config.enable &&
+    var.public_sentries_config.enable &&
+  contains(var.public_sentries_config.regions, 1)) ? 1 : 0
+
+  source = "./public-sentries"
+  providers = {
+    google      = google.region_1
+    google.peer = google.region_1
+  }
+
+  labels = local.labels
+
+  nodes_count           = var.public_sentries_config.nodes_count
+  instance_type         = var.public_sentries_config.instance_type
+  service_account_email = module.iam.service_account_email
+
+  enable_ipv6 = var.public_sentries_config.enable_ipv6
+
+  ssh_public_key_path  = var.ssh_public_key_path
+  ssh_private_key_path = var.ssh_private_key_path
+
+  region_index = 1
+  peer_vpc     = module.private_sentries[0].vpc
+}
+
+# Public Sentries region 2
+module "public_sentries_2" {
+  count = (var.private_sentries_config.enable &&
+    var.public_sentries_config.enable &&
+  contains(var.public_sentries_config.regions, 2)) ? 1 : 0
+
+  source = "./public-sentries"
+  providers = {
+    google      = google.region_2
+    google.peer = google.region_1
+  }
+
+  labels = local.labels
+
+  nodes_count           = var.public_sentries_config.nodes_count
+  instance_type         = var.public_sentries_config.instance_type
+  service_account_email = module.iam.service_account_email
+
+  enable_ipv6 = var.public_sentries_config.enable_ipv6
+
+  ssh_public_key_path  = var.ssh_public_key_path
+  ssh_private_key_path = var.ssh_private_key_path
+
+  region_index = 2
+  peer_vpc     = module.private_sentries[0].vpc
+}
+
+# Observers region 1
+module "observers_1" {
+  count = (var.private_sentries_config.enable &&
+    var.observers_config.enable &&
+  contains(var.observers_config.regions, 1)) ? 1 : 0
+
+  source = "./observers"
+  providers = {
+    google      = google.region_1
+    google.peer = google.region_1
+  }
+
+  labels = local.labels
+
+  nodes_count           = var.observers_config.nodes_count
+  instance_type         = var.observers_config.instance_type
+  service_account_email = module.iam.service_account_email
+
+  root_domain_name = var.observers_config.root_domain_name
+  enable_tls       = var.observers_config.enable_tls
+
+  ssh_public_key_path  = var.ssh_public_key_path
+  ssh_private_key_path = var.ssh_private_key_path
+
+  region_index = 1
+  peer_vpc     = module.private_sentries[0].vpc
+}
+
+# Observers region 2
+module "observers_2" {
+  count = (var.private_sentries_config.enable &&
+    var.observers_config.enable &&
+  contains(var.observers_config.regions, 2)) ? 1 : 0
+
+  source = "./observers"
+  providers = {
+    google      = google.region_2
+    google.peer = google.region_1
+  }
+
+  labels = local.labels
+
+  nodes_count           = var.observers_config.nodes_count
+  instance_type         = var.observers_config.instance_type
+  service_account_email = module.iam.service_account_email
+
+  root_domain_name = var.observers_config.root_domain_name
+  enable_tls       = var.observers_config.enable_tls
+
+  ssh_public_key_path  = var.ssh_public_key_path
+  ssh_private_key_path = var.ssh_private_key_path
+
+  region_index = 2
+  peer_vpc     = module.private_sentries[0].vpc
+}
+
+module "prometheus" {
+  count = local.prometheus_enabled ? 1 : 0
+
+  source = "./prometheus"
+  providers = {
+    google = google.region_1
+  }
+
+  labels = local.labels
+
+  instance_type = var.prometheus_config.instance_type
+  endpoints     = local.prometheus_endpoints
+
+  ssh_public_key_path  = var.ssh_public_key_path
+  ssh_private_key_path = var.ssh_private_key_path
+
+  vpc = module.private_sentries[0].vpc
+}

--- a/deployment/terraform/gcp/observers/main.tf
+++ b/deployment/terraform/gcp/observers/main.tf
@@ -1,0 +1,70 @@
+resource "google_compute_instance_template" "observer" {
+  labels = var.labels
+
+  name_prefix  = "observer-template"
+  machine_type = var.machine_type
+
+  disk {
+    source_image = "ubuntu-os-pro-cloud/ubuntu-minimal-pro-2004-lts"
+
+    auto_delete = true
+    boot        = true
+  }
+
+  network_interface {
+    access_config {}
+  }
+
+  service_account {
+    email  = var.service_account_email
+    scopes = ["cloud-platform"]
+  }
+
+  tags = ["observer"]
+}
+
+resource "google_compute_region_instance_group_manager" "observer" {
+  name               = "observer-group"
+  base_instance_name = "observer"
+  version {
+    instance_template = google_compute_instance_template.observer.id
+  }
+  target_size = var.instance_count
+  auto_healing_policies {
+    health_check      = google_compute_health_check.observer.id
+    initial_delay_sec = 30
+  }
+}
+
+data "google_compute_region_instance_group" "observer" {
+  name = google_compute_region_instance_group_manager.observer.name
+}
+
+resource "google_compute_instance" "observer" {
+  for_each     = toset(data.google_compute_region_instance_group.observer.instances)
+  name         = basename(each.value)
+  zone         = google_compute_region_instance_group_manager.observer.region
+  project      = var.project_id
+  machine_type = var.machine_type
+  boot_disk {
+    initialize_params {
+      image = var.boot_image
+    }
+  }
+  network_interface {
+    access_config {
+    }
+  }
+}
+
+resource "google_compute_health_check" "observer" {
+  name                = "observer-health-check"
+  check_interval_sec  = 10
+  timeout_sec         = 5
+  healthy_threshold   = 2
+  unhealthy_threshold = 3
+
+  http_health_check {
+    port = 80
+  }
+}

--- a/deployment/terraform/gcp/observers/outputs.tf
+++ b/deployment/terraform/gcp/observers/outputs.tf
@@ -1,0 +1,12 @@
+output "instance_group_name" {
+  value = google_compute_region_instance_group_manager.observer.name
+}
+
+output "instance_ips" {
+  value = {
+    for k, v in google_compute_instance.observer : k => {
+      external_ip = v.network_interface[0].access_config[0].nat_ip
+      internal_ip = v.network_interface[0].network_ip
+    }
+  }
+}

--- a/deployment/terraform/gcp/observers/provider.tf
+++ b/deployment/terraform/gcp/observers/provider.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source                = "hashicorp/google"
+      version               = ">= 4.1"
+      configuration_aliases = [google, google.peer]
+    }
+  }
+}

--- a/deployment/terraform/gcp/observers/variables.tf
+++ b/deployment/terraform/gcp/observers/variables.tf
@@ -1,0 +1,45 @@
+variable "labels" {
+  description = "A map of labels to add to all applicable resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "project_id" {
+  description = "The GCP Project ID"
+  type = string
+}
+
+variable "machine_type" {
+  type    = string
+}
+
+variable "instance_count" {
+  type    = number
+  default = 2
+}
+
+variable "boot_image" {
+  description = "Image to use for the boot disk"
+  type        = string
+  default     = local.default_source_image
+}
+
+variable "region_index" {
+  description = "Observer Region Index"
+}
+
+variable "enable_tls" {
+  description = "Enable TLS on LB listeners"
+}
+
+variable "root_domain_name" {
+  description = "Root domain name"
+}
+
+variable "peer_vpc" {
+  description = "Peer VPC"
+}
+
+variable "service_account_email" {
+  type = string
+}

--- a/deployment/terraform/gcp/outputs.tf
+++ b/deployment/terraform/gcp/outputs.tf
@@ -1,0 +1,19 @@
+output "nodes" {
+  value = local.nodes
+}
+
+output "common_labels" {
+  value = local.labels
+}
+
+output "prometheus_endpoint" {
+  value = local.prometheus_endpoint
+}
+
+output "ansible_inventory" {
+  value = local.ansible_inventory
+}
+
+output "ansible_inventory_yaml" {
+  value = yamlencode(local.ansible_inventory)
+}

--- a/deployment/terraform/gcp/private-sentries/main.tf
+++ b/deployment/terraform/gcp/private-sentries/main.tf
@@ -1,0 +1,34 @@
+resource "google_compute_instance_template" "private_sentry_template" {
+  labels = var.labels
+
+  name_prefix  = "private-sentry-template"
+  machine_type = var.machine_type
+  region       = var.region
+
+  disk {
+    source_image = var.boot_image
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    subnetwork = var.subnetwork
+  }
+
+  service_account {
+    email  = var.service_account_email
+    scopes = ["cloud-platform"]
+  }
+
+  tags = ["private-sentry"]
+}
+
+resource "google_compute_region_instance_group_manager" "private_sentry_group" {
+  name                = "private-sentry-group"
+  base_instance_name  = "private-sentry"
+  region              = var.region
+  version {
+    instance_template = google_compute_instance_template.private_sentry_template.id
+  }
+  target_size         = var.instance_count
+}

--- a/deployment/terraform/gcp/private-sentries/outputs.tf
+++ b/deployment/terraform/gcp/private-sentries/outputs.tf
@@ -1,0 +1,3 @@
+output "private_sentry_group_name" {
+  value = google_compute_region_instance_group_manager.private_sentry_group.name
+}

--- a/deployment/terraform/gcp/private-sentries/provider.tf
+++ b/deployment/terraform/gcp/private-sentries/provider.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source                = "hashicorp/google"
+      version               = ">= 4.1"
+      configuration_aliases = [google, google.peer]
+    }
+  }
+}

--- a/deployment/terraform/gcp/private-sentries/variables.tf
+++ b/deployment/terraform/gcp/private-sentries/variables.tf
@@ -1,0 +1,36 @@
+variable "labels" {
+  description = "A map of labels to add to all applicable resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "project_id" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "subnetwork" {
+  type = string
+}
+
+variable "service_account_email" {
+  type = string
+}
+
+variable "machine_type" {
+  type    = string
+  default = "e2-medium"
+}
+
+variable "boot_image" {
+  type    = string
+  default = "debian-cloud/debian-11"
+}
+
+variable "instance_count" {
+  type    = number
+  default = 2
+}

--- a/deployment/terraform/gcp/prometheus/main.tf
+++ b/deployment/terraform/gcp/prometheus/main.tf
@@ -1,0 +1,27 @@
+resource "google_compute_instance" "prometheus" {
+  labels = var.labels
+
+  name         = "dcl-prometheus"
+  machine_type = var.machine_type
+  zone         = var.zone
+
+  boot_disk {
+    initialize_params {
+      image = var.boot_image
+    }
+  }
+
+  network_interface {
+    subnetwork         = var.subnetwork
+    access_config {}
+  }
+
+  service_account {
+    email  = var.service_account_email
+    scopes = ["monitoring", "logging-write", "cloud-platform"]
+  }
+
+  metadata_startup_script = var.startup_script
+
+  tags = ["prometheus"]
+}

--- a/deployment/terraform/gcp/prometheus/outputs.tf
+++ b/deployment/terraform/gcp/prometheus/outputs.tf
@@ -1,0 +1,3 @@
+output "prometheus_ip" {
+  value = google_compute_instance.prometheus.network_interface[0].access_config[0].nat_ip
+}

--- a/deployment/terraform/gcp/prometheus/provider.tf
+++ b/deployment/terraform/gcp/prometheus/provider.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source                = "hashicorp/google"
+      version               = ">= 4.1"
+      configuration_aliases = [google, google.peer]
+    }
+  }
+}

--- a/deployment/terraform/gcp/prometheus/variables.tf
+++ b/deployment/terraform/gcp/prometheus/variables.tf
@@ -1,0 +1,43 @@
+variable "labels" {
+  description = "A map of labels to add to all applicable resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "project_id" {
+  type = string
+}
+
+variable "zone" {
+  type = string
+}
+
+variable "machine_type" {
+  type    = string
+  default = "e2-medium"
+}
+
+variable "boot_image" {
+  type    = string
+  default = "debian-cloud/debian-11"
+}
+
+variable "subnetwork" {
+  type = string
+}
+
+variable "service_account_email" {
+  type = string
+}
+
+variable "startup_script" {
+  type        = string
+  description = "Startup script to install and configure Prometheus"
+  default     = <<-EOT
+#!/bin/bash
+sudo apt-get update
+sudo apt-get install -y prometheus
+sudo systemctl enable prometheus
+sudo systemctl start prometheus
+EOT
+}

--- a/deployment/terraform/gcp/provider.tf
+++ b/deployment/terraform/gcp/provider.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    google = {
+      source                = "hashicorp/google"
+      version               = "~>4.1.0"
+      configuration_aliases = [google, google.peer]
+    }
+  }
+}

--- a/deployment/terraform/gcp/provisioner/cloudwatch-config.tpl
+++ b/deployment/terraform/gcp/provisioner/cloudwatch-config.tpl
@@ -1,0 +1,28 @@
+{
+    "agent": {
+      "metrics_collection_interval": 10,
+      "logfile": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log",
+      "run_as_user": "root"
+    },
+    "logs": {
+      "logs_collected": {
+        "files": {
+          "collect_list": [
+            {
+              "file_path": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log",
+              "log_group_name": "/apps/CloudWatchAgentLog/",
+              "log_stream_name": "{ip_address}_{instance_id}",
+              "timezone": "Local"
+            },
+            {
+              "file_path": "/var/log/cosmovisor/cosmovisor.log",
+              "log_group_name":  "/apps/cosmovisor/",
+              "log_stream_name": "{ip_address}_{instance_id}",
+              "timestamp_format": "%b %d %H:%M:%S",
+              "timezone": "Local"
+            }
+          ]
+        }
+      }
+    }
+  }

--- a/deployment/terraform/gcp/provisioner/install-ansible-deps.sh
+++ b/deployment/terraform/gcp/provisioner/install-ansible-deps.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Copyright 2020 DSR Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends python3

--- a/deployment/terraform/gcp/provisioner/install-cloudwatch.sh
+++ b/deployment/terraform/gcp/provisioner/install-cloudwatch.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright 2020 DSR Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+wget https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
+sudo dpkg -i amazon-cloudwatch-agent.deb
+
+sudo cp /tmp/cloudwatch-config.json /opt/aws/amazon-cloudwatch-agent/bin/config.json
+
+sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json -s

--- a/deployment/terraform/gcp/provisioner/install-prometheus-service.sh
+++ b/deployment/terraform/gcp/provisioner/install-prometheus-service.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Copyright 2020 DSR Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PROMETHEUS_VERSION=2.26.0
+
+sudo useradd --no-create-home --shell /bin/false prometheus
+sudo useradd --no-create-home --shell /bin/false node_exporter
+
+sudo mkdir /etc/prometheus
+sudo mkdir /var/lib/prometheus
+
+sudo mkdir /etc/prometheus
+sudo mkdir /var/lib/prometheus
+
+sudo chown -R prometheus:prometheus /var/lib/prometheus/
+
+cd ~
+curl -LO https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz
+
+tar xvf prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz
+
+
+sudo cp prometheus-${PROMETHEUS_VERSION}.linux-amd64/prometheus /usr/local/bin/
+sudo cp prometheus-${PROMETHEUS_VERSION}.linux-amd64/promtool /usr/local/bin/
+
+sudo chown prometheus:prometheus /usr/local/bin/prometheus
+sudo chown prometheus:prometheus /usr/local/bin/promtool
+
+sudo cp -r prometheus-${PROMETHEUS_VERSION}.linux-amd64/consoles /etc/prometheus
+sudo cp -r prometheus-${PROMETHEUS_VERSION}.linux-amd64/console_libraries /etc/prometheus
+
+sudo chown -R prometheus:prometheus /etc/prometheus/consoles
+sudo chown -R prometheus:prometheus /etc/prometheus/console_libraries
+
+rm -rf prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz prometheus-${PROMETHEUS_VERSION}.linux-amd64
+
+
+sudo cp /tmp/prometheus.yml /etc/prometheus
+sudo chown prometheus:prometheus /etc/prometheus/prometheus.yml
+
+sudo tee /etc/systemd/system/prometheus.service<<EOF
+[Unit]
+Description=Prometheus
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=prometheus
+Group=prometheus
+Type=simple
+ExecStart=/usr/local/bin/prometheus \
+    --config.file /etc/prometheus/prometheus.yml \
+    --storage.tsdb.path /var/lib/prometheus/ \
+    --web.console.templates=/etc/prometheus/consoles \
+    --web.console.libraries=/etc/prometheus/console_libraries
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl start prometheus
+sudo systemctl enable prometheus

--- a/deployment/terraform/gcp/provisioner/prometheus.tpl
+++ b/deployment/terraform/gcp/provisioner/prometheus.tpl
@@ -1,0 +1,19 @@
+global:
+  scrape_interval: 15s
+  external_labels:
+    monitor: '${monitor}'
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: [${targets}]
+
+remote_write:
+  -
+    url: ${prometheus_endpoint}api/v1/remote_write
+    queue_config:
+        max_samples_per_send: 1000
+        max_shards: 200
+        capacity: 2500
+    sigv4:
+        region: ${region}

--- a/deployment/terraform/gcp/public-sentries/main.tf
+++ b/deployment/terraform/gcp/public-sentries/main.tf
@@ -1,0 +1,50 @@
+resource "google_compute_instance_template" "sentry_template" {
+  labels = var.labels
+
+  name_prefix  = "sentry-template"
+  machine_type = var.machine_type
+  region       = var.region
+
+  disk {
+    source_image = var.boot_image
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    access_config {}
+  }
+
+  service_account {
+    email  = var.service_account_email
+    scopes = ["cloud-platform"]
+  }
+
+  tags = ["public-sentry"]
+}
+
+resource "google_compute_region_instance_group_manager" "sentry_group" {
+  name                = "sentry-group"
+  base_instance_name  = "sentry"
+  region              = var.region
+  version {
+    instance_template = google_compute_instance_template.sentry_template.id
+  }
+  target_size         = var.instance_count
+  auto_healing_policies {
+    health_check      = google_compute_health_check.default.id
+    initial_delay_sec = 30
+  }
+}
+
+resource "google_compute_health_check" "default" {
+  name               = "sentry-health-check"
+  check_interval_sec = 10
+  timeout_sec        = 5
+  healthy_threshold  = 2
+  unhealthy_threshold = 3
+
+  http_health_check {
+    port = 80
+  }
+}

--- a/deployment/terraform/gcp/public-sentries/outputs.tf
+++ b/deployment/terraform/gcp/public-sentries/outputs.tf
@@ -1,0 +1,3 @@
+output "instance_group_name" {
+  value = google_compute_region_instance_group_manager.sentry_group.name
+}

--- a/deployment/terraform/gcp/public-sentries/provider.tf
+++ b/deployment/terraform/gcp/public-sentries/provider.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source                = "hashicorp/google"
+      version               = ">= 4.1"
+      configuration_aliases = [google, google.peer]
+    }
+  }
+}

--- a/deployment/terraform/gcp/public-sentries/variables.tf
+++ b/deployment/terraform/gcp/public-sentries/variables.tf
@@ -1,0 +1,32 @@
+variable "labels" {
+  description = "A map of labels to add to all applicable resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "project_id" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "service_account_email" {
+  type = string
+}
+
+variable "machine_type" {
+  type    = string
+  default = "e2-medium"
+}
+
+variable "boot_image" {
+  type    = string
+  default = "debian-cloud/debian-11"
+}
+
+variable "instance_count" {
+  type    = number
+  default = 2
+}

--- a/deployment/terraform/gcp/validator/main.tf
+++ b/deployment/terraform/gcp/validator/main.tf
@@ -1,0 +1,25 @@
+resource "google_compute_instance" "validator" {
+  labels = var.labels
+
+  name                = "dcl-validator"
+  machine_type        = var.instance_type
+  deletion_protection = !var.disable_instance_protection
+
+  boot_disk {
+    initialize_params {
+      image = var.boot_image
+    }
+  }
+
+  network_interface {
+    subnetwork = var.subnetwork
+    access_config {} # enables external IP
+  }
+
+  service_account {
+    email  = var.service_account_email
+    scopes = ["cloud-platform"]
+  }
+
+  tags = ["validator"]
+}

--- a/deployment/terraform/gcp/validator/outputs.tf
+++ b/deployment/terraform/gcp/validator/outputs.tf
@@ -1,0 +1,7 @@
+output "instance_name" {
+  value = google_compute_instance.validator.name
+}
+
+output "instance_ip" {
+  value = google_compute_instance.validator.network_interface[0].access_config[0].nat_ip
+}

--- a/deployment/terraform/gcp/validator/provider.tf
+++ b/deployment/terraform/gcp/validator/provider.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    google = {
+      source                = "hashicorp/google"
+      version               = ">= 4.1"
+      configuration_aliases = [google, google.peer]
+    }
+  }
+}

--- a/deployment/terraform/gcp/validator/variables.tf
+++ b/deployment/terraform/gcp/validator/variables.tf
@@ -1,0 +1,35 @@
+variable "labels" {
+  description = "A map of labels to add to all applicable resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "disable_instance_protection" {
+  description = "Disable the protection that prevents the validator instance from being accidentally terminated"
+  type        = bool
+  default     = false
+}
+
+variable "project_id" {
+  type = string
+}
+
+variable "instance_type" {
+  type = string
+}
+
+variable "boot_image" {
+  description = "Image to use for the boot disk"
+  type        = string
+  default     = local.default_source_image
+}
+
+variable "subnetwork" {
+  description = "The subnetwork to deploy the instance into"
+  type        = string
+}
+
+variable "service_account_email" {
+  description = "IAM service account email"
+  type        = string
+}

--- a/deployment/terraform/gcp/variables.tf
+++ b/deployment/terraform/gcp/variables.tf
@@ -1,0 +1,93 @@
+variable "common_labels" {
+  description = "Common tags for resources created in AWS."
+  type = object({
+    project     = optional(string) # default: DCL
+    environment = optional(string) # default: workspace name
+    created-by  = optional(string) # e.g. email address
+    purpose     = optional(string)
+  })
+}
+
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+  default     = "DCL"
+}
+
+variable "region_1" {
+  type    = string
+  default = "us-east1"
+}
+
+variable "region_2" {
+  type    = string
+  default = "us-west1"
+}
+
+variable "zone" {
+  type    = string
+  default = "us-east1-b"
+}
+
+variable "subnetwork" {
+  type = string
+}
+
+variable "service_account_email" {
+  type = string
+}
+
+variable "validator_config" {
+  type = object({
+    instance_type = string
+    is_genesis    = bool
+  })
+}
+
+variable "disable_validator_protection" {
+  description = "Disable the protection that prevents the validator instance from being accidentally terminated"
+  type        = bool
+  default     = false
+}
+
+variable "private_sentries_config" {
+  type = object({
+    enable        = bool
+    nodes_count   = number
+    instance_type = string
+  })
+
+  description = "Public Sentries config"
+}
+
+variable "public_sentries_config" {
+  type = object({
+    enable        = bool
+    enable_ipv6   = bool
+    nodes_count   = number
+    instance_type = string
+    regions       = set(number)
+  })
+
+  description = "Public Sentries config"
+}
+
+variable "observers_config" {
+  type = object({
+    enable           = bool
+    nodes_count      = number
+    instance_type    = string
+    root_domain_name = string
+    enable_tls       = bool
+    regions          = set(number)
+  })
+
+  description = "Observers config"
+}
+
+variable "prometheus_config" {
+  type = object({
+    enable        = bool
+    instance_type = string
+  })
+}

--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -4,117 +4,56 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 3.72"
     }
-  }
-}
-
-# Configure the AWS Provider
-provider "aws" {
-  region = var.region
-}
-
-module "dcl_sg" {
-  source  = "terraform-aws-modules/security-group/aws"
-  version = "~> 4.0"
-
-  name        = "dcl-security_group"
-  description = "Security group for accessing DCL nodes from outside"
-  vpc_id      = module.network_lab.vpc_id
-
-  ingress_cidr_blocks = ["0.0.0.0/0"]
-  ingress_rules       = ["all-icmp", "ssh-tcp"]
-  egress_rules        = ["all-all"]
-  ingress_with_cidr_blocks = [
-    {
-      from_port   = 26656
-      to_port     = 26656
-      protocol    = "tcp"
-      description = "DCL p2p"
-      cidr_blocks = "0.0.0.0/0"
-    },
-    {
-      from_port   = 26657
-      to_port     = 26657
-      protocol    = "tcp"
-      description = "DCL RPC"
-      cidr_blocks = "0.0.0.0/0"
-    },
-  ]
-}
-
-resource "aws_instance" "dcl_node" {
-  ami           = data.aws_ami.ubuntu.id
-  instance_type = "c5.4xlarge"
-
-  subnet_id              = element(module.network_lab.public_subnets, 0)
-  vpc_security_group_ids = [module.dcl_sg.security_group_id]
-
-  key_name   = aws_key_pair.key_pair.id
-  monitoring = true
-
-  root_block_device {
-    encrypted   = true
-    volume_size = 20
-  }
-
-  connection {
-    type        = "ssh"
-    host        = self.public_ip
-    user        = var.ssh_username
-    private_key = file(var.ssh_private_key_path)
-  }
-
-  provisioner "remote-exec" {
-    inline = [
-      "sudo apt-get update",
-      "sudo apt-get install -y --no-install-recommends python3",
-    ]
-  }
-
-  provisioner "local-exec" {
-    command = "ansible-playbook -i ../ansible/inventory/aws_ec2.yml -u ${var.ssh_username} ../ansible/deploy.yml"
-    environment = {
-      ANSIBLE_HOST_KEY_CHECKING = "False"
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.0"
     }
   }
+}
 
-  metadata_options {
-    http_endpoint = "enabled"
-    http_tokens   = "required"
+provider "aws" {
+  region     = var.region
+  alias      = "aws"
+  skip_credentials_validation = false
+  skip_metadata_api_check     = false
+  skip_region_validation      = false
+  count      = var.cloud_provider == "aws" ? 1 : 0
+}
+
+provider "google" {
+  project = var.gcp_project
+  region  = var.gcp_regions[0]
+  alias   = "gcp"
+  count   = var.cloud_provider == "gcp" ? 1 : 0
+}
+
+# AWS Infrastructure
+module "aws_infra" {
+  source           = "./aws"
+  region           = var.region
+  ssh_username     = var.ssh_username
+  ssh_public_key_path  = var.ssh_public_key_path
+  ssh_private_key_path = var.ssh_private_key_path
+
+  providers = {
+    aws = aws
   }
+
+  count = var.cloud_provider == "aws" ? 1 : 0
 }
 
-data "aws_ami" "ubuntu" {
-  most_recent = true
-  owners      = ["099720109477"]
+# GCP Infrastructure
+module "gcp_infra" {
+  source           = "./gcp"
+  project_id       = var.gcp_project
+  regions          = var.gcp_regions
+  ssh_username     = var.ssh_username
+  ssh_public_key_path  = var.ssh_public_key_path
+  ssh_private_key_path = var.ssh_private_key_path
 
-  filter {
-    name   = "name"
-    values = ["ubuntu-minimal/images/hvm-ssd/ubuntu-focal-20.04-amd64-minimal-*"]
+  providers = {
+    google = google
   }
 
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-}
-
-resource "aws_key_pair" "key_pair" {
-  public_key = file(var.ssh_public_key_path)
-}
-
-data "aws_availability_zones" "available" {
-  state = "available"
-}
-
-module "network_lab" {
-  source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 3.0"
-
-  name = "dcl-network"
-  cidr = "10.0.0.0/16"
-
-  azs                = [data.aws_availability_zones.available.names[0]]
-  private_subnets    = ["10.0.1.0/24"]
-  public_subnets     = ["10.0.101.0/24"]
-  enable_nat_gateway = true
+  count = var.cloud_provider == "gcp" ? 1 : 0
 }

--- a/deployment/terraform/outputs.tf
+++ b/deployment/terraform/outputs.tf
@@ -1,3 +1,6 @@
 output "ssh_console" {
-  value = format("ssh -o 'StrictHostKeyChecking=no' ubuntu@%s", aws_instance.dcl_node.public_ip)
+  value = var.cloud_provider == "aws" ?
+    format("ssh -o 'StrictHostKeyChecking=no' %s@%s", var.ssh_username, module.aws_infra[0].public_ip) :
+    format("ssh -o 'StrictHostKeyChecking=no' %s@%s", var.ssh_username, module.gcp_infra[0].public_ip)
+  description = "SSH command to connect to the DCL node"
 }

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -1,3 +1,27 @@
+variable "cloud_provider" {
+  description = "Cloud provider to deploy resources to (aws or gcp)"
+  type        = string
+  default     = "aws"
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-west-1"
+}
+
+variable "gcp_project" {
+  description = "GCP project ID"
+  type        = string
+  default     = "DCL"
+}
+
+variable "gcp_regions" {
+  description = "List of GCP regions to deploy resources"
+  type        = list(string)
+  default     = ["us-east1", "us-west1"]
+}
+
 variable "ssh_public_key_path" {
   description = "SSH public key file path"
   default     = "~/.ssh/id_rsa.pub"
@@ -11,9 +35,4 @@ variable "ssh_private_key_path" {
 variable "ssh_username" {
   description = "SSH username"
   default     = "ubuntu"
-}
-
-variable "region" {
-  description = "AWS Region"
-  default     = "us-west-1"
 }


### PR DESCRIPTION
This is a WIP PR containing the initial structure for GCP resources.
Still missing networking definition.
Still have to rearrange modules interfaces: check up all variables and outputs.
Also there are at least a couple of points to discuss:
- should we use `google_compute_region_instance_group_manager` or better `google_compute_instance` with count?
- are we good with `oslogin` or still have to manage ssh keys like we do in AWS?
And more other work to be done.

@andkononykhin @Toktar