### PR TITLE
Add OtaChecksumType validation per Matter Spec R1.4.2

### DIFF
--- a/x/model/types/errors.go
+++ b/x/model/types/errors.go
@@ -29,6 +29,7 @@ var (
 	ErrModelDeletionCertified             = errors.Register(ModuleName, 525, "model has a model version that has a compliance record and  correcponding model can not be deleted")
 	ErrFieldIsNotBase64Encoded            = errors.Register(ModuleName, 526, "Field is not base64 encoded string")
 	ErrEnhancedSetupFlowTCRevisionInvalid = errors.Register(ModuleName, 527, "enhanced setup flow TC revision invalid")
+	ErrOtaChecksumTypeInvalid             = errors.Register(ModuleName, 528, "OTA checksum type is not valid")
 )
 
 func NewErrModelAlreadyExists(vid interface{}, pid interface{}) error {
@@ -148,4 +149,10 @@ func NewErrEnhancedSetupFlowTCDigestIsNotBase64Encoded(enhancedSetupFlowTCDigest
 func NewErrEnhancedSetupFlowTCRevisionInvalidIncrement(newEnhancedSetupFlowTCRevision int32, prevEnhancedSetupFlowTCRevision int32) error {
 	return errors.Wrapf(ErrEnhancedSetupFlowTCRevisionInvalid,
 		"EnhancedSetupFlowTCRevision %v is not correctly incremented to %v", prevEnhancedSetupFlowTCRevision, newEnhancedSetupFlowTCRevision)
+}
+
+func NewErrOtaChecksumTypeInvalid(otaChecksumType int32) error {
+	return errors.Wrapf(ErrOtaChecksumTypeInvalid,
+		"OtaChecksumType %v is not valid. Must be one of [1, 7, 8, 10, 11, 12] per IANA Named Information Hash Algorithm Registry",
+		otaChecksumType)
 }

--- a/x/model/types/messages_model_version.go
+++ b/x/model/types/messages_model_version.go
@@ -80,6 +80,19 @@ func (msg *MsgCreateModelVersion) GetSignBytes() []byte {
 	return sdk.MustSortJSON(bz)
 }
 
+var ValidOtaChecksumTypes = map[int32]bool{
+	1:  true, // sha-256
+	7:  true, // sha-384
+	8:  true, // sha-512
+	10: true, // sha3-256
+	11: true, // sha3-384
+	12: true, // sha3-512
+}
+
+func IsValidOtaChecksumType(checksumType int32) bool {
+	return ValidOtaChecksumTypes[checksumType]
+}
+
 func (msg *MsgCreateModelVersion) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
@@ -89,6 +102,10 @@ func (msg *MsgCreateModelVersion) ValidateBasic() error {
 	_, err = base64.StdEncoding.DecodeString(msg.OtaChecksum)
 	if err != nil {
 		return NewErrOtaChecksumIsNotBase64Encoded(msg.OtaChecksum)
+	}
+
+	if msg.OtaUrl != "" && !IsValidOtaChecksumType(msg.OtaChecksumType) {
+		return NewErrOtaChecksumTypeInvalid(msg.OtaChecksumType)
 	}
 
 	err = validator.Validate(msg)

--- a/x/model/types/messages_model_version_test.go
+++ b/x/model/types/messages_model_version_test.go
@@ -208,25 +208,67 @@ func TestMsgCreateModelVersion_ValidateBasic(t *testing.T) {
 
 				return msg
 			}(validMsgCreateModelVersion()),
-			err: validator.ErrRequiredFieldMissing,
+			err: ErrOtaChecksumTypeInvalid,
 		},
 		{
-			name: "OtaChecksumType < 0",
+			name: "OtaChecksumType < 0 when OtaUrl is set",
 			msg: func(msg *MsgCreateModelVersion) *MsgCreateModelVersion {
+				msg.OtaUrl = "https://sampleflowurl.dclmodel"
 				msg.OtaChecksumType = -1
 
 				return msg
 			}(validMsgCreateModelVersion()),
-			err: validator.ErrFieldLowerBoundViolated,
+			err: ErrOtaChecksumTypeInvalid,
 		},
 		{
-			name: "OtaChecksumType > 65535",
+			name: "OtaChecksumType > 65535 when OtaUrl is set",
 			msg: func(msg *MsgCreateModelVersion) *MsgCreateModelVersion {
+				msg.OtaUrl = "https://sampleflowurl.dclmodel"
 				msg.OtaChecksumType = 65536
 
 				return msg
 			}(validMsgCreateModelVersion()),
-			err: validator.ErrFieldUpperBoundViolated,
+			err: ErrOtaChecksumTypeInvalid,
+		},
+		{
+			name: "OtaChecksumType == 2 is not in allowed list when OtaUrl is set",
+			msg: func(msg *MsgCreateModelVersion) *MsgCreateModelVersion {
+				msg.OtaUrl = "https://sampleflowurl.dclmodel"
+				msg.OtaChecksumType = 2
+
+				return msg
+			}(validMsgCreateModelVersion()),
+			err: ErrOtaChecksumTypeInvalid,
+		},
+		{
+			name: "OtaChecksumType == 3 is not in allowed list when OtaUrl is set",
+			msg: func(msg *MsgCreateModelVersion) *MsgCreateModelVersion {
+				msg.OtaUrl = "https://sampleflowurl.dclmodel"
+				msg.OtaChecksumType = 3
+
+				return msg
+			}(validMsgCreateModelVersion()),
+			err: ErrOtaChecksumTypeInvalid,
+		},
+		{
+			name: "OtaChecksumType == 9 is not in allowed list when OtaUrl is set",
+			msg: func(msg *MsgCreateModelVersion) *MsgCreateModelVersion {
+				msg.OtaUrl = "https://sampleflowurl.dclmodel"
+				msg.OtaChecksumType = 9
+
+				return msg
+			}(validMsgCreateModelVersion()),
+			err: ErrOtaChecksumTypeInvalid,
+		},
+		{
+			name: "OtaChecksumType == 100 is not in allowed list when OtaUrl is set",
+			msg: func(msg *MsgCreateModelVersion) *MsgCreateModelVersion {
+				msg.OtaUrl = "https://sampleflowurl.dclmodel"
+				msg.OtaChecksumType = 100
+
+				return msg
+			}(validMsgCreateModelVersion()),
+			err: ErrOtaChecksumTypeInvalid,
 		},
 		{
 			name: "MinApplicableSoftwareVersion > MaxApplicableSoftwareVersion " +
@@ -488,17 +530,55 @@ func TestMsgCreateModelVersion_ValidateBasic(t *testing.T) {
 			}(validMsgCreateModelVersion()),
 		},
 		{
-			name: "OtaChecksumType == 1",
+			name: "OtaChecksumType == 1 (sha-256)",
 			msg: func(msg *MsgCreateModelVersion) *MsgCreateModelVersion {
+				msg.OtaUrl = "https://sampleflowurl.dclmodel"
 				msg.OtaChecksumType = 1
 
 				return msg
 			}(validMsgCreateModelVersion()),
 		},
 		{
-			name: "OtaChecksumType == 65535",
+			name: "OtaChecksumType == 7 (sha-384)",
 			msg: func(msg *MsgCreateModelVersion) *MsgCreateModelVersion {
-				msg.OtaChecksumType = 65535
+				msg.OtaUrl = "https://sampleflowurl.dclmodel"
+				msg.OtaChecksumType = 7
+
+				return msg
+			}(validMsgCreateModelVersion()),
+		},
+		{
+			name: "OtaChecksumType == 8 (sha-512)",
+			msg: func(msg *MsgCreateModelVersion) *MsgCreateModelVersion {
+				msg.OtaUrl = "https://sampleflowurl.dclmodel"
+				msg.OtaChecksumType = 8
+
+				return msg
+			}(validMsgCreateModelVersion()),
+		},
+		{
+			name: "OtaChecksumType == 10 (sha3-256)",
+			msg: func(msg *MsgCreateModelVersion) *MsgCreateModelVersion {
+				msg.OtaUrl = "https://sampleflowurl.dclmodel"
+				msg.OtaChecksumType = 10
+
+				return msg
+			}(validMsgCreateModelVersion()),
+		},
+		{
+			name: "OtaChecksumType == 11 (sha3-384)",
+			msg: func(msg *MsgCreateModelVersion) *MsgCreateModelVersion {
+				msg.OtaUrl = "https://sampleflowurl.dclmodel"
+				msg.OtaChecksumType = 11
+
+				return msg
+			}(validMsgCreateModelVersion()),
+		},
+		{
+			name: "OtaChecksumType == 12 (sha3-512)",
+			msg: func(msg *MsgCreateModelVersion) *MsgCreateModelVersion {
+				msg.OtaUrl = "https://sampleflowurl.dclmodel"
+				msg.OtaChecksumType = 12
 
 				return msg
 			}(validMsgCreateModelVersion()),


### PR DESCRIPTION
### Background
The Connectivity Standards Alliance Distributed Compliance Ledger (DCL) does not enforce the Matter Specification requirements for validating OtaChecksumType in OTA Software Image records. The DCL accepts any integer value from 0 to 65535, including reserved values, unassigned values, and weak hash algorithms with less than 256-bit security. According to the Matter Specification, only values [1, 7, 8, 10, 11, 12] representing ≥256-bit hash algorithms (sha-256, sha-384, sha-512, sha3-256, sha3-384, sha3-512) **shall** be accepted. This may lead to firmware update failures or undefined behavior in downstream OTA Providers and Matter devices that cannot interpret invalid hash algorithm identifiers.
This pull request introduces stricter validation for the `OtaChecksumType` field in the `MsgCreateModelVersion` message, ensuring that only specific, IANA-approved checksum types are allowed when an OTA URL is provided. It also updates error handling and unit tests to reflect these new requirements.

### Validation and error handling improvements:

* Added a new error type, `ErrOtaChecksumTypeInvalid`, and an associated error constructor to handle cases where the OTA checksum type is not valid. (`x/model/types/errors.go`) [[1]](diffhunk://#diff-694d03421f3e5af31240da506de5f5659dac6377ac790801307fa23df8fe65c4R32) [[2]](diffhunk://#diff-694d03421f3e5af31240da506de5f5659dac6377ac790801307fa23df8fe65c4R153-R158)
* Implemented a map of valid OTA checksum types and an `IsValidOtaChecksumType` helper function to check if a given checksum type is allowed. (`x/model/types/messages_model_version.go`)
* Updated the `ValidateBasic` method for `MsgCreateModelVersion` to enforce that the OTA checksum type must be one of the allowed values if an OTA URL is set, returning the new error if validation fails. (`x/model/types/messages_model_version.go`)

Unit test updates:

* Modified and expanded unit tests for `MsgCreateModelVersion.ValidateBasic` to cover invalid and valid OTA checksum types, ensuring proper error handling and coverage for all allowed and disallowed values. (`x/model/types/messages_model_version_test.go`) [[1]](diffhunk://#diff-04f27d534924afea2a7fb1c142c35469fa070f63cdc949e1d063b9e065a791a6L211-R271) [[2]](diffhunk://#diff-04f27d534924afea2a7fb1c142c35469fa070f63cdc949e1d063b9e065a791a6L491-R581)