### PR TITLE
Remove checking Model Version while adding Device Software Compliance record

### DIFF
--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -307,8 +307,6 @@ dcld tx vendorinfo update-vendor --vid=<uint16> ... --from=<vendor-admin-account
 
 This step is needed for on-ledger certification use case only, see [use_cases_device_on_ledger_certification](use_cases/use_cases_device_on_ledger_certification.png).
 
-The corresponding model and the version must be present on the ledger.
-
 ```bash
 dcld tx compliance certify-model --vid=<uint16> --pid=<uint16> --softwareVersion=<uint32> --softwareVersionString=<string>  --certificationType=<matter|zigbee> --certificationDate=<rfc3339 encoded date> --reason=<string> --from=<account>
 ```

--- a/docs/transactions/compliance.md
+++ b/docs/transactions/compliance.md
@@ -11,8 +11,6 @@ Attests compliance of the Model Version to the ZB or Matter standard.
 `REVOKE_MODEL_CERTIFICATION` should be used for revoking (disabling) the compliance.
 It's possible to call `CERTIFY_MODEL` for revoked model versions to enable them back.
 
-The corresponding Model and Model Version must be present on the ledger.
-
 It must be called for every compliant device for use cases where compliance
 is tracked on ledger.
 

--- a/docs/transactions/compliance.md
+++ b/docs/transactions/compliance.md
@@ -11,6 +11,8 @@ Attests compliance of the Model Version to the ZB or Matter standard.
 `REVOKE_MODEL_CERTIFICATION` should be used for revoking (disabling) the compliance.
 It's possible to call `CERTIFY_MODEL` for revoked model versions to enable them back.
 
+The corresponding Model and Model Version are not required to be present in the ledger. It can be added later by Vendors.
+
 It must be called for every compliant device for use cases where compliance
 is tracked on ledger.
 

--- a/docs/transactions/model.md
+++ b/docs/transactions/model.md
@@ -136,6 +136,8 @@ If one of Model Versions associated with the Model is certified then Model can n
 Adds a new Model Software Version identified by a unique combination of `vid` (vendor ID), `pid` (product ID) and `softwareVersion`.
 If `account` was created with product ID ranges then the `pid` must fall within that specified range
 
+If the corresponding Compliance Info record already exists in the ledger, the Software Version and CD Version number must match the one being added.
+
 Not all Model Software Version fields can be edited (see `EDIT_MODEL_VERSION`).
 
 If one of `OTA_URl`, `OTA_checksum` or `OTA_checksum_type` fields is set, then the other two must also be set.

--- a/integration_tests/cli/compliance-demo-hex.sh
+++ b/integration_tests/cli/compliance-demo-hex.sh
@@ -54,15 +54,6 @@ check_response "$result" "\"code\": 0"
 
 test_divider
 
-echo "Certify unknown Model Version with VID: $vid_in_hex_format PID: $pid_in_hex_format  SV: ${sv} with zigbee certification"
-result=$(echo "$passphrase" | dcld tx compliance certify-model --vid=$vid_in_hex_format --pid=$pid_in_hex_format --softwareVersion=$sv --softwareVersionString=$svs --certificationType="$zigbee_certification_type" --certificationDate="$certification_date" --cdCertificateId="$cd_certificate_id" --from $zb_account --yes)
-result=$(get_txn_result "$result")
-echo "$result"
-check_response "$result" "\"code\": 517"
-check_response "$result" "No model version"
-
-test_divider
-
 echo "Add Model Version with VID: $vid_in_hex_format PID: $pid_in_hex_format SV: $sv SoftwareVersionString:$svs"
 result=$(echo '$passphrase' | dcld tx model add-model-version --cdVersionNumber=1 --maxApplicableSoftwareVersion=10 --minApplicableSoftwareVersion=1 --vid=$vid_in_hex_format --pid=$pid_in_hex_format --softwareVersion=$sv --softwareVersionString=$svs --from=$vendor_account --yes)
 result=$(get_txn_result "$result")

--- a/integration_tests/cli/compliance-demo.sh
+++ b/integration_tests/cli/compliance-demo.sh
@@ -45,12 +45,26 @@ matter_certification_type="matter"
 cd_certificate_id="123"
 cd_version_number=1
 schema_version_0=0
+
 echo "Certify unknown Model with VID: $vid PID: $pid  SV: ${sv} with zigbee certification"
 result=$(echo "$passphrase" | dcld tx compliance certify-model --vid=$vid --pid=$pid --softwareVersion=$sv --softwareVersionString=$svs --certificationType="$zigbee_certification_type" --certificationDate="$certification_date" --cdCertificateId="$cd_certificate_id" --from $zb_account --yes)
 result=$(get_txn_result "$result")
 echo "$result"
-check_response "$result" "\"code\": 517"
-check_response "$result" "No model version"
+check_response "$result" "\"code\": 0"
+
+echo "Get Device Software Compliance with CDCertificateID: {$cd_certificate_id}"
+result=$(dcld query compliance device-software-compliance --cdCertificateId="$cd_certificate_id")
+check_response "$result" "\"vid\": $vid"
+check_response "$result" "\"pid\": $pid"
+check_response "$result" "\"softwareVersion\": $sv"
+check_response "$result" "\"softwareVersionString\": \"$svs\""
+check_response "$result" "\"certificationType\": \"$zigbee_certification_type\""
+check_response "$result" "\"date\": \"$certification_date\""
+check_response "$result" "\"cDCertificateId\": \"$cd_certificate_id\""
+
+echo "Delete compliance info vid=$vid pid=$pid softwareVersion=$sv certificationType=$zigbee_certification_type"
+result=$(echo "$passphrase" | dcld tx compliance delete-compliance-info --vid=$vid --pid=$pid --softwareVersion=$sv --certificationType=$zigbee_certification_type --from=$zb_account --yes)
+result=$(get_txn_result "$result")
 
 test_divider
 
@@ -59,15 +73,6 @@ result=$(echo "$passphrase" | dcld tx model add-model --vid=$vid --pid=$pid --de
 result=$(get_txn_result "$result")
 echo $result
 check_response "$result" "\"code\": 0"
-
-test_divider
-
-echo "Certify unknown Model Version with VID: $vid PID: $pid  SV: ${sv} with zigbee certification"
-result=$(echo "$passphrase" | dcld tx compliance certify-model --vid=$vid --pid=$pid --softwareVersion=$sv --softwareVersionString=$svs --certificationType="$zigbee_certification_type" --certificationDate="$certification_date" --cdCertificateId="$cd_certificate_id" --from $zb_account --yes)
-result=$(get_txn_result "$result")
-echo "$result"
-check_response "$result" "\"code\": 517"
-check_response "$result" "No model version"
 
 test_divider
 

--- a/integration_tests/cli/compliance-provisioning.sh
+++ b/integration_tests/cli/compliance-provisioning.sh
@@ -37,10 +37,40 @@ sv=$RANDOM
 svs=$RANDOM
 certification_type_zb="zigbee"
 certification_type_matter="matter"
+certification_date="2020-01-02T02:20:20Z"
+certification_reason="some reason"
+cd_certificate_id="1"
+schema_version_0=0
+
+test_divider
+
+echo "Certify Model with VID: $vid PID: $pid SV: ${sv} for Matter when Model Version does not exist yet"
+result=$(echo "$passphrase" | dcld tx compliance certify-model --vid=$vid --pid=$pid --softwareVersion=$sv --softwareVersionString=$svs --certificationType="$certification_type_matter" --certificationDate="$certification_date" --reason "$certification_reason" --cdCertificateId="$cd_certificate_id" --cdVersionNumber=1 --from $zb_account --yes)
+result=$(get_txn_result "$result")
+check_response "$result" "\"code\": 0"
+echo "$result"
+
+test_divider
+
+echo "Get Device Software Compliance with CDCertificateID: {$cd_certificate_id}"
+result=$(dcld query compliance device-software-compliance --cdCertificateId="$cd_certificate_id")
+check_response "$result" "\"vid\": $vid"
+check_response "$result" "\"pid\": $pid"
+check_response "$result" "\"softwareVersion\": $sv"
+check_response "$result" "\"softwareVersionString\": \"$svs\""
+check_response "$result" "\"certificationType\": \"$certification_type_matter\""
+check_response "$result" "\"date\": \"$certification_date\""
+check_response "$result" "\"reason\": \"$certification_reason\""
+check_response "$result" "\"cDCertificateId\": \"$cd_certificate_id\""
+
+test_divider
+
+pid=$RANDOM
+sv=$RANDOM
+svs=$RANDOM
 provision_date="2020-02-02T02:20:20Z"
 provision_reason="some reason"
 cd_certificate_id="123"
-schema_version_0=0
 
 test_divider
 

--- a/integration_tests/cli/compliance-provisioning.sh
+++ b/integration_tests/cli/compliance-provisioning.sh
@@ -37,40 +37,10 @@ sv=$RANDOM
 svs=$RANDOM
 certification_type_zb="zigbee"
 certification_type_matter="matter"
-certification_date="2020-01-02T02:20:20Z"
-certification_reason="some reason"
-cd_certificate_id="1"
-schema_version_0=0
-
-test_divider
-
-echo "Certify Model with VID: $vid PID: $pid SV: ${sv} for Matter when Model Version does not exist yet"
-result=$(echo "$passphrase" | dcld tx compliance certify-model --vid=$vid --pid=$pid --softwareVersion=$sv --softwareVersionString=$svs --certificationType="$certification_type_matter" --certificationDate="$certification_date" --reason "$certification_reason" --cdCertificateId="$cd_certificate_id" --cdVersionNumber=1 --from $zb_account --yes)
-result=$(get_txn_result "$result")
-check_response "$result" "\"code\": 0"
-echo "$result"
-
-test_divider
-
-echo "Get Device Software Compliance with CDCertificateID: {$cd_certificate_id}"
-result=$(dcld query compliance device-software-compliance --cdCertificateId="$cd_certificate_id")
-check_response "$result" "\"vid\": $vid"
-check_response "$result" "\"pid\": $pid"
-check_response "$result" "\"softwareVersion\": $sv"
-check_response "$result" "\"softwareVersionString\": \"$svs\""
-check_response "$result" "\"certificationType\": \"$certification_type_matter\""
-check_response "$result" "\"date\": \"$certification_date\""
-check_response "$result" "\"reason\": \"$certification_reason\""
-check_response "$result" "\"cDCertificateId\": \"$cd_certificate_id\""
-
-test_divider
-
-pid=$RANDOM
-sv=$RANDOM
-svs=$RANDOM
 provision_date="2020-02-02T02:20:20Z"
 provision_reason="some reason"
 cd_certificate_id="123"
+schema_version_0=0
 
 test_divider
 

--- a/integration_tests/cli/modelversion-demo.sh
+++ b/integration_tests/cli/modelversion-demo.sh
@@ -25,6 +25,8 @@ vendor_account=vendor_account_$vid
 echo "Create Vendor account - $vendor_account"
 create_new_vendor_account $vendor_account $vid
 
+echo "Create CertificationCenter account"
+create_new_account zb_account "CertificationCenter"
 
 # Create a new model version
 echo "Add Model with VID: $vid PID: $pid"
@@ -36,6 +38,13 @@ test_divider
 
 sv=$RANDOM
 schema_version_0=0
+
+echo "Certify  Model with VID: $vid PID: $pid  SV: ${sv} with zigbee certification"
+result=$(echo "test1234" | dcld tx compliance certify-model --vid=$vid --pid=$pid --softwareVersion=$sv --cdVersionNumber=1 --softwareVersionString=1 --cdCertificateId=1 --certificationType=zigbee --certificationDate="2020-01-01T00:00:01Z" --from $zb_account --yes)
+result=$(get_txn_result "$result")
+echo "$result"
+check_response "$result" "\"code\": 0"
+
 echo "Create a Device Model Version with VID: $vid PID: $pid SV: $sv"
 result=$(echo 'test1234' | dcld tx model add-model-version --cdVersionNumber=1 --maxApplicableSoftwareVersion=10 --minApplicableSoftwareVersion=1 --vid=$vid --pid=$pid --softwareVersion=$sv --softwareVersionString=1   --schemaVersion=$schema_version_0 --from=$vendor_account --yes)
 result=$(get_txn_result "$result")

--- a/integration_tests/cli/modelversion-demo.sh
+++ b/integration_tests/cli/modelversion-demo.sh
@@ -162,6 +162,11 @@ result=$(echo 'test1234' | dcld tx model update-model-version --vid=$vid --pid=$
 result=$(get_txn_result "$result")
 check_response_and_report "$result" "transaction should be signed by a vendor account containing the vendorID $vid"
 
+# Delete corresponding compliance info
+echo "Delete compliance info vid=$vid pid=$pid softwareVersion=$sv certificationType=zigbee"
+result=$(echo 'test1234' | dcld tx compliance delete-compliance-info --vid=$vid --pid=$pid --softwareVersion=$sv --certificationType=zigbee --from=$zb_account --yes)
+result=$(get_txn_result "$result")
+
 # Delete existing model version
 echo "Delete a Device Model Version with VID: $vid PID: $pid SV: $sv"
 result=$(echo 'test1234' | dcld tx model delete-model-version --vid=$vid --pid=$pid --softwareVersion=$sv --from=$vendor_account --yes)

--- a/integration_tests/grpc_rest/compliance/helpers.go
+++ b/integration_tests/grpc_rest/compliance/helpers.go
@@ -944,6 +944,9 @@ func DemoTrackCompliance(suite *utils.TestSuite) {
 	require.Equal(suite.T, certDate, deviceSoftwareCompliance.ComplianceInfo[0].Date)
 
 	inputAllComplianceInfo, _ = GetAllComplianceInfo(suite)
+	inputAllCertifiedModels, _ = GetAllCertifiedModels(suite)
+	inputAllDeviceSoftwareCompliance, _ = GetAllDeviceSoftwareCompliance(suite)
+
 	pid = int32(tmrand.Uint16())
 	sv = tmrand.Uint32()
 	svs = utils.RandString()

--- a/integration_tests/grpc_rest/compliance/helpers.go
+++ b/integration_tests/grpc_rest/compliance/helpers.go
@@ -943,6 +943,7 @@ func DemoTrackCompliance(suite *utils.TestSuite) {
 	require.Equal(suite.T, certReason, deviceSoftwareCompliance.ComplianceInfo[0].Reason)
 	require.Equal(suite.T, certDate, deviceSoftwareCompliance.ComplianceInfo[0].Date)
 
+	inputAllComplianceInfo, _ = GetAllComplianceInfo(suite)
 	pid = int32(tmrand.Uint16())
 	sv = tmrand.Uint32()
 	svs = utils.RandString()

--- a/integration_tests/grpc_rest/compliance/helpers.go
+++ b/integration_tests/grpc_rest/compliance/helpers.go
@@ -875,20 +875,11 @@ func DemoTrackCompliance(suite *utils.TestSuite) {
 	)
 	require.NotNil(suite.T, certCenterAccount)
 
-	// Publish model info
 	pid := int32(tmrand.Uint16())
-	firstModel := testModel.NewMsgCreateModel(vid, pid, vendorAccount.Address)
-	_, err = suite.BuildAndBroadcastTx([]sdk.Msg{firstModel}, vendorName, vendorAccount)
-	require.NoError(suite.T, err)
-
-	// Publish modelVersion
 	sv := tmrand.Uint32()
 	svs := utils.RandString()
-	firstModelVersion := testModel.NewMsgCreateModelVersion(vid, pid, sv, svs, vendorAccount.Address)
-	_, err = suite.BuildAndBroadcastTx([]sdk.Msg{firstModelVersion}, vendorName, vendorAccount)
-	require.NoError(suite.T, err)
 
-	// Check if model either certified or revoked before Compliance record was created
+	// Check if the model either certified or revoked before the Compliance record was created
 	_, err = GetComplianceInfo(suite, vid, pid, sv, compliancetypes.ZigbeeCertificationType)
 	suite.AssertNotFound(err)
 	_, err = GetRevokedModel(suite, vid, pid, sv, compliancetypes.ZigbeeCertificationType)
@@ -898,10 +889,77 @@ func DemoTrackCompliance(suite *utils.TestSuite) {
 	_, err = GetProvisionalModel(suite, vid, pid, sv, compliancetypes.ZigbeeCertificationType)
 	suite.AssertNotFound(err)
 
-	// Certify model
-	certReason := testconstants.Reason + "1"
+	// Certify a device when Model Version does not exist yet
+	certReason := testconstants.Reason + "0"
+	cdCertificateID := testconstants.CDCertificateID + "1"
 	certDate := testconstants.FirstJanuary
 	certifyModelMsg := compliancetypes.MsgCertifyModel{
+		Vid:                   vid,
+		Pid:                   pid,
+		SoftwareVersion:       sv,
+		SoftwareVersionString: svs,
+		CertificationDate:     certDate,
+		CertificationType:     "zigbee",
+		Reason:                certReason,
+		CDCertificateId:       cdCertificateID,
+		CDVersionNumber:       uint32(testconstants.CdVersionNumber),
+		Signer:                certCenterAccount.Address,
+	}
+	_, err = suite.BuildAndBroadcastTx([]sdk.Msg{&certifyModelMsg}, certCenter, certCenterAccount)
+	require.NoError(suite.T, err)
+
+	// Certify model again
+	_, err = suite.BuildAndBroadcastTx([]sdk.Msg{&certifyModelMsg}, certCenter, certCenterAccount)
+	require.Error(suite.T, err)
+	require.True(suite.T, compliancetypes.ErrAlreadyCertified.Is(err))
+
+	// Check model is certified
+	complianceInfo, _ := GetComplianceInfo(suite, vid, pid, sv, compliancetypes.ZigbeeCertificationType)
+	require.Equal(suite.T, compliancetypes.ZigbeeCertificationType, complianceInfo.CertificationType)
+	require.Equal(suite.T, uint32(2), complianceInfo.SoftwareVersionCertificationStatus)
+	require.Equal(suite.T, vid, complianceInfo.Vid)
+	require.Equal(suite.T, pid, complianceInfo.Pid)
+	require.Equal(suite.T, sv, complianceInfo.SoftwareVersion)
+	require.Equal(suite.T, cdCertificateID, complianceInfo.CDCertificateId)
+	require.Equal(suite.T, certReason, complianceInfo.Reason)
+	require.Equal(suite.T, certDate, complianceInfo.Date)
+	modelIsCertified, _ := GetCertifiedModel(suite, vid, pid, sv, compliancetypes.ZigbeeCertificationType)
+	require.True(suite.T, modelIsCertified.Value)
+	modelIsRevoked, _ := GetRevokedModel(suite, vid, pid, sv, compliancetypes.ZigbeeCertificationType)
+	require.False(suite.T, modelIsRevoked.Value)
+	modelIsProvisional, _ := GetProvisionalModel(suite, vid, pid, sv, compliancetypes.ZigbeeCertificationType)
+	require.False(suite.T, modelIsProvisional.Value)
+
+	// Check device software compliance
+	deviceSoftwareCompliance, _ := GetDeviceSoftwareCompliance(suite, cdCertificateID)
+	require.Equal(suite.T, cdCertificateID, deviceSoftwareCompliance.CDCertificateId)
+	require.Equal(suite.T, 1, len(deviceSoftwareCompliance.ComplianceInfo))
+	require.Equal(suite.T, compliancetypes.ZigbeeCertificationType, deviceSoftwareCompliance.ComplianceInfo[0].CertificationType)
+	require.Equal(suite.T, uint32(2), deviceSoftwareCompliance.ComplianceInfo[0].SoftwareVersionCertificationStatus)
+	require.Equal(suite.T, vid, deviceSoftwareCompliance.ComplianceInfo[0].Vid)
+	require.Equal(suite.T, pid, deviceSoftwareCompliance.ComplianceInfo[0].Pid)
+	require.Equal(suite.T, sv, deviceSoftwareCompliance.ComplianceInfo[0].SoftwareVersion)
+	require.Equal(suite.T, cdCertificateID, deviceSoftwareCompliance.ComplianceInfo[0].CDCertificateId)
+	require.Equal(suite.T, certReason, deviceSoftwareCompliance.ComplianceInfo[0].Reason)
+	require.Equal(suite.T, certDate, deviceSoftwareCompliance.ComplianceInfo[0].Date)
+
+	pid = int32(tmrand.Uint16())
+	sv = tmrand.Uint32()
+	svs = utils.RandString()
+	// Publish model info
+	firstModel := testModel.NewMsgCreateModel(vid, pid, vendorAccount.Address)
+	_, err = suite.BuildAndBroadcastTx([]sdk.Msg{firstModel}, vendorName, vendorAccount)
+	require.NoError(suite.T, err)
+
+	// Publish modelVersion
+	firstModelVersion := testModel.NewMsgCreateModelVersion(vid, pid, sv, svs, vendorAccount.Address)
+	_, err = suite.BuildAndBroadcastTx([]sdk.Msg{firstModelVersion}, vendorName, vendorAccount)
+	require.NoError(suite.T, err)
+
+	// Certify model
+	certReason = testconstants.Reason + "1"
+	certDate = testconstants.FirstJanuary
+	certifyModelMsg = compliancetypes.MsgCertifyModel{
 		Vid:                   vid,
 		Pid:                   pid,
 		SoftwareVersion:       sv,
@@ -922,7 +980,7 @@ func DemoTrackCompliance(suite *utils.TestSuite) {
 	require.True(suite.T, compliancetypes.ErrAlreadyCertified.Is(err))
 
 	// Check model is certified
-	complianceInfo, _ := GetComplianceInfo(suite, vid, pid, sv, compliancetypes.ZigbeeCertificationType)
+	complianceInfo, _ = GetComplianceInfo(suite, vid, pid, sv, compliancetypes.ZigbeeCertificationType)
 	require.Equal(suite.T, compliancetypes.ZigbeeCertificationType, complianceInfo.CertificationType)
 	require.Equal(suite.T, uint32(2), complianceInfo.SoftwareVersionCertificationStatus)
 	require.Equal(suite.T, vid, complianceInfo.Vid)
@@ -931,15 +989,15 @@ func DemoTrackCompliance(suite *utils.TestSuite) {
 	require.Equal(suite.T, testconstants.CDCertificateID, complianceInfo.CDCertificateId)
 	require.Equal(suite.T, certReason, complianceInfo.Reason)
 	require.Equal(suite.T, certDate, complianceInfo.Date)
-	modelIsCertified, _ := GetCertifiedModel(suite, vid, pid, sv, compliancetypes.ZigbeeCertificationType)
+	modelIsCertified, _ = GetCertifiedModel(suite, vid, pid, sv, compliancetypes.ZigbeeCertificationType)
 	require.True(suite.T, modelIsCertified.Value)
-	modelIsRevoked, _ := GetRevokedModel(suite, vid, pid, sv, compliancetypes.ZigbeeCertificationType)
+	modelIsRevoked, _ = GetRevokedModel(suite, vid, pid, sv, compliancetypes.ZigbeeCertificationType)
 	require.False(suite.T, modelIsRevoked.Value)
-	modelIsProvisional, _ := GetProvisionalModel(suite, vid, pid, sv, compliancetypes.ZigbeeCertificationType)
+	modelIsProvisional, _ = GetProvisionalModel(suite, vid, pid, sv, compliancetypes.ZigbeeCertificationType)
 	require.False(suite.T, modelIsProvisional.Value)
 
 	// Check device software compliance
-	deviceSoftwareCompliance, _ := GetDeviceSoftwareCompliance(suite, testconstants.CDCertificateID)
+	deviceSoftwareCompliance, _ = GetDeviceSoftwareCompliance(suite, testconstants.CDCertificateID)
 	require.Equal(suite.T, testconstants.CDCertificateID, deviceSoftwareCompliance.CDCertificateId)
 	require.Equal(suite.T, 1, len(deviceSoftwareCompliance.ComplianceInfo))
 	require.Equal(suite.T, compliancetypes.ZigbeeCertificationType, deviceSoftwareCompliance.ComplianceInfo[0].CertificationType)

--- a/x/compliance/client/cli/tx_certify_model.go
+++ b/x/compliance/client/cli/tx_certify_model.go
@@ -41,7 +41,7 @@ func CmdCertifyModel() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "certify-model",
-		Short: "Certify an existing model. Note that either corresponding model version and test results or revocation info must be present on ledger",
+		Short: "Certify an existing model",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx, err := client.GetClientTxContext(cmd)

--- a/x/model/handler_test.go
+++ b/x/model/handler_test.go
@@ -797,6 +797,9 @@ func TestHandler_DeleteModelAfterDeletingModelVersion(t *testing.T) {
 	_, err := setup.Handler(setup.Ctx, msgCreateModel)
 	require.NoError(t, err)
 
+	complianceKeeper := setup.ComplianceKeeper
+	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false)
+
 	// add two new model versions
 	msgCreateModelVersion1 := NewMsgCreateModelVersion(setup.Vendor, testconstants.SoftwareVersion)
 	_, err = setup.Handler(setup.Ctx, msgCreateModelVersion1)
@@ -806,7 +809,7 @@ func TestHandler_DeleteModelAfterDeletingModelVersion(t *testing.T) {
 	_, err = setup.Handler(setup.Ctx, msgCreateModelVersion2)
 	require.NoError(t, err)
 
-	complianceKeeper := setup.ComplianceKeeper
+	complianceKeeper = setup.ComplianceKeeper
 	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false)
 
 	msgDeleteModelVersion1 := NewMsgDeleteModelVersion(setup.Vendor)
@@ -832,6 +835,8 @@ func TestHandler_DeleteModelWithAssociatedModelVersionsNotCertified(t *testing.T
 	_, err := setup.Handler(setup.Ctx, msgCreateModel)
 	require.NoError(t, err)
 
+	complianceKeeper := setup.ComplianceKeeper
+	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false)
 	// add two new model versions
 	msgCreateModelVersion1 := NewMsgCreateModelVersion(setup.Vendor, testconstants.SoftwareVersion)
 	_, err = setup.Handler(setup.Ctx, msgCreateModelVersion1)
@@ -842,7 +847,6 @@ func TestHandler_DeleteModelWithAssociatedModelVersionsNotCertified(t *testing.T
 	require.NoError(t, err)
 
 	// mock model versions not to be certified
-	complianceKeeper := setup.ComplianceKeeper
 	complianceKeeper.On("GetComplianceInfo", mock.Anything, msgCreateModelVersion1.Vid, msgCreateModelVersion1.Pid, msgCreateModelVersion1.SoftwareVersion, mock.Anything).Return(false)
 	complianceKeeper.On("GetComplianceInfo", mock.Anything, msgCreateModelVersion2.Vid, msgCreateModelVersion2.Pid, msgCreateModelVersion2.SoftwareVersion, mock.Anything).Return(false)
 	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(true)
@@ -885,17 +889,20 @@ func TestHandler_DeleteModelWithAssociatedModelVersionsCertified(t *testing.T) {
 	_, err := setup.Handler(setup.Ctx, msgCreateModel)
 	require.NoError(t, err)
 
+	complianceKeeper := setup.ComplianceKeeper
+
 	// add two new model versions
 	msgCreateModelVersion1 := NewMsgCreateModelVersion(setup.Vendor, testconstants.SoftwareVersion)
+	complianceKeeper.On("GetComplianceInfo", mock.Anything, msgCreateModelVersion1.Vid, msgCreateModelVersion1.Pid, msgCreateModelVersion1.SoftwareVersion, mock.Anything).Times(len(dclcompltypes.CertificationTypesList)).Return(false)
 	_, err = setup.Handler(setup.Ctx, msgCreateModelVersion1)
 	require.NoError(t, err)
 
 	msgCreateModelVersion2 := NewMsgCreateModelVersion(setup.Vendor, testconstants.SoftwareVersion+1)
+	complianceKeeper.On("GetComplianceInfo", mock.Anything, msgCreateModelVersion2.Vid, msgCreateModelVersion2.Pid, msgCreateModelVersion2.SoftwareVersion, mock.Anything).Times(len(dclcompltypes.CertificationTypesList)).Return(false)
 	_, err = setup.Handler(setup.Ctx, msgCreateModelVersion2)
 	require.NoError(t, err)
 
 	// mock one model version to be certified
-	complianceKeeper := setup.ComplianceKeeper
 	complianceKeeper.On("GetComplianceInfo", mock.Anything, msgCreateModelVersion1.Vid, msgCreateModelVersion1.Pid, msgCreateModelVersion1.SoftwareVersion, mock.Anything).Return(false)
 	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(true)
 
@@ -1030,6 +1037,8 @@ func TestHandler_AddModelVersion(t *testing.T) {
 
 	// add new model
 	msgCreateModel := NewMsgCreateModel(setup.Vendor)
+	complianceKeeper := setup.ComplianceKeeper
+	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false)
 	_, err := setup.Handler(setup.Ctx, msgCreateModel)
 	require.NoError(t, err)
 
@@ -1076,6 +1085,9 @@ func TestHandler_AddMultipleModelVersions(t *testing.T) {
 	msgCreateModel := NewMsgCreateModel(setup.Vendor)
 	_, err := setup.Handler(setup.Ctx, msgCreateModel)
 	require.NoError(t, err)
+
+	complianceKeeper := setup.ComplianceKeeper
+	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false)
 
 	// add new model version 1
 	msgCreateModelVersion1 := NewMsgCreateModelVersion(setup.Vendor, uint32(1))
@@ -1145,6 +1157,9 @@ func TestHandler_UpdateModelVersion(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, types.ErrModelVersionDoesNotExist.Is(err))
 
+	complianceKeeper := setup.ComplianceKeeper
+	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false)
+
 	// add new model version
 	msgCreateModelVersion := NewMsgCreateModelVersion(setup.Vendor, testconstants.SoftwareVersion)
 	_, err = setup.Handler(setup.Ctx, msgCreateModelVersion)
@@ -1213,6 +1228,9 @@ func TestHandler_UpdateModelVersionByVendorWithProductIds(t *testing.T) {
 	_, err := setup.Handler(setup.Ctx, msgCreteModel)
 	require.NoError(t, err)
 
+	complianceKeeper := setup.ComplianceKeeper
+	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false)
+
 	// add new model version
 	msgCreateModelVersion := NewMsgCreateModelVersion(owner, testconstants.SoftwareVersion)
 	msgCreateModelVersion.Pid = 200
@@ -1254,6 +1272,8 @@ func TestHandler_PartiallyUpdateModelVersion(t *testing.T) {
 	_, err := setup.Handler(setup.Ctx, msgCreateModel)
 	require.NoError(t, err)
 
+	complianceKeeper := setup.ComplianceKeeper
+	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false)
 	// add new model version
 	msgCreateModelVersion := NewMsgCreateModelVersion(setup.Vendor, testconstants.SoftwareVersion)
 	_, err = setup.Handler(setup.Ctx, msgCreateModelVersion)
@@ -1303,6 +1323,8 @@ func TestHandler_UpdateOnlyMinApplicableSoftwareVersion(t *testing.T) {
 	_, err := setup.Handler(setup.Ctx, msgCreateModel)
 	require.NoError(t, err)
 
+	complianceKeeper := setup.ComplianceKeeper
+	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false)
 	// add new model version
 	msgCreateModelVersion := NewMsgCreateModelVersion(setup.Vendor, testconstants.SoftwareVersion)
 	msgCreateModelVersion.MinApplicableSoftwareVersion = 5
@@ -1373,6 +1395,8 @@ func TestHandler_UpdateOnlyMaxApplicableSoftwareVersion(t *testing.T) {
 	_, err := setup.Handler(setup.Ctx, msgCreateModel)
 	require.NoError(t, err)
 
+	complianceKeeper := setup.ComplianceKeeper
+	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false)
 	// add new model version
 	msgCreateModelVersion := NewMsgCreateModelVersion(setup.Vendor, testconstants.SoftwareVersion)
 	msgCreateModelVersion.MinApplicableSoftwareVersion = 5
@@ -1443,6 +1467,8 @@ func TestHandler_UpdateOTAFieldsInitiallyNotSet(t *testing.T) {
 	_, err := setup.Handler(setup.Ctx, msgCreateModel)
 	require.NoError(t, err)
 
+	complianceKeeper := setup.ComplianceKeeper
+	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false)
 	// add new model version
 	msgCreateModelVersion := NewMsgCreateModelVersion(setup.Vendor, testconstants.SoftwareVersion)
 	msgCreateModelVersion.OtaUrl = ""
@@ -1484,6 +1510,8 @@ func TestHandler_UpdateOTAFieldsInitiallySet(t *testing.T) {
 	_, err := setup.Handler(setup.Ctx, msgCreateModel)
 	require.NoError(t, err)
 
+	complianceKeeper := setup.ComplianceKeeper
+	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false)
 	// add new model version
 	msgCreateModelVersion := NewMsgCreateModelVersion(setup.Vendor, testconstants.SoftwareVersion)
 
@@ -1523,6 +1551,8 @@ func TestHandler_OnlyOwnerAndVendorWithSameVidCanUpdateModelVersion(t *testing.T
 	_, err := setup.Handler(setup.Ctx, msgCreteModel)
 	require.NoError(t, err)
 
+	complianceKeeper := setup.ComplianceKeeper
+	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false)
 	// add new model version
 	msgCreateModelVersion := NewMsgCreateModelVersion(setup.Vendor, testconstants.SoftwareVersion)
 	_, err = setup.Handler(setup.Ctx, msgCreateModelVersion)
@@ -1577,6 +1607,8 @@ func TestHandler_DeleteModelVersion(t *testing.T) {
 	_, err := setup.Handler(setup.Ctx, msgCreateModel)
 	require.NoError(t, err)
 
+	complianceKeeper := setup.ComplianceKeeper
+	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false)
 	// add new model version
 	msgCreateModelVersion := NewMsgCreateModelVersion(setup.Vendor, testconstants.SoftwareVersion)
 	_, err = setup.Handler(setup.Ctx, msgCreateModelVersion)
@@ -1584,7 +1616,6 @@ func TestHandler_DeleteModelVersion(t *testing.T) {
 
 	msgDeleteModelVersion := NewMsgDeleteModelVersion(setup.Vendor)
 
-	complianceKeeper := setup.ComplianceKeeper
 	complianceKeeper.On("GetComplianceInfo", mock.Anything, msgDeleteModelVersion.Vid, msgDeleteModelVersion.Pid, msgDeleteModelVersion.SoftwareVersion, mock.Anything).Return(false)
 	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(true)
 
@@ -1619,6 +1650,9 @@ func TestHandler_DeleteOneOfTwoModelVersions(t *testing.T) {
 	_, err := setup.Handler(setup.Ctx, msgCreateModel)
 	require.NoError(t, err)
 
+	complianceKeeper := setup.ComplianceKeeper
+	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false)
+
 	// add two new model versions
 	msgCreateModelVersion1 := NewMsgCreateModelVersion(setup.Vendor, testconstants.SoftwareVersion)
 	_, err = setup.Handler(setup.Ctx, msgCreateModelVersion1)
@@ -1629,7 +1663,6 @@ func TestHandler_DeleteOneOfTwoModelVersions(t *testing.T) {
 	require.NoError(t, err)
 
 	// mock model versions not to be certified
-	complianceKeeper := setup.ComplianceKeeper
 	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false)
 
 	msgDeleteModelVersion := NewMsgDeleteModelVersion(setup.Vendor)
@@ -1669,6 +1702,8 @@ func TestHandler_DeleteModelVersionDifferentAccSameVid(t *testing.T) {
 	_, err := setup.Handler(setup.Ctx, msgCreateModel)
 	require.NoError(t, err)
 
+	complianceKeeper := setup.ComplianceKeeper
+	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false)
 	// add new model version
 	msgCreateModelVersion := NewMsgCreateModelVersion(setup.Vendor, testconstants.SoftwareVersion)
 	_, err = setup.Handler(setup.Ctx, msgCreateModelVersion)
@@ -1681,7 +1716,6 @@ func TestHandler_DeleteModelVersionDifferentAccSameVid(t *testing.T) {
 
 	msgDeleteModelVersion := NewMsgDeleteModelVersion(secondAcc)
 
-	complianceKeeper := setup.ComplianceKeeper
 	complianceKeeper.On("GetComplianceInfo", mock.Anything, msgDeleteModelVersion.Vid, msgDeleteModelVersion.Pid, msgDeleteModelVersion.SoftwareVersion, mock.Anything).Return(false)
 	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(true)
 
@@ -1707,6 +1741,8 @@ func TestHandler_DeleteModelVersionNotByVendor(t *testing.T) {
 	_, err := setup.Handler(setup.Ctx, msgCreateModel)
 	require.NoError(t, err)
 
+	complianceKeeper := setup.ComplianceKeeper
+	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false)
 	// add new model version
 	msgCreateModelVersion := NewMsgCreateModelVersion(setup.Vendor, testconstants.SoftwareVersion)
 	_, err = setup.Handler(setup.Ctx, msgCreateModelVersion)
@@ -1727,6 +1763,8 @@ func TestHandler_DeleteModelVersionDifferentVid(t *testing.T) {
 	_, err := setup.Handler(setup.Ctx, msgCreateModel)
 	require.NoError(t, err)
 
+	complianceKeeper := setup.ComplianceKeeper
+	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false)
 	// add new model version
 	msgCreateModelVersion := NewMsgCreateModelVersion(setup.Vendor, testconstants.SoftwareVersion)
 	_, err = setup.Handler(setup.Ctx, msgCreateModelVersion)
@@ -1747,6 +1785,8 @@ func TestHandler_DeleteModelVersionDoesNotExist(t *testing.T) {
 	_, err := setup.Handler(setup.Ctx, msgCreateModel)
 	require.NoError(t, err)
 
+	complianceKeeper := setup.ComplianceKeeper
+	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false)
 	// add new model version
 	msgCreateModelVersion := NewMsgCreateModelVersion(setup.Vendor, testconstants.SoftwareVersion)
 	_, err = setup.Handler(setup.Ctx, msgCreateModelVersion)
@@ -1767,6 +1807,8 @@ func TestHandler_DeleteModelVersionNotByCreator(t *testing.T) {
 	_, err := setup.Handler(setup.Ctx, msgCreateModel)
 	require.NoError(t, err)
 
+	complianceKeeper := setup.ComplianceKeeper
+	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false)
 	// add new model version
 	msgCreateModelVersion := NewMsgCreateModelVersion(setup.Vendor, testconstants.SoftwareVersion)
 	_, err = setup.Handler(setup.Ctx, msgCreateModelVersion)
@@ -1788,6 +1830,8 @@ func TestHandler_DeleteModelVersionCertified(t *testing.T) {
 	_, err := setup.Handler(setup.Ctx, msgCreateModel)
 	require.NoError(t, err)
 
+	complianceKeeper := setup.ComplianceKeeper
+	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Times(len(dclcompltypes.CertificationTypesList)).Return(false)
 	// add new model version
 	msgCreateModelVersion := NewMsgCreateModelVersion(setup.Vendor, testconstants.SoftwareVersion)
 	_, err = setup.Handler(setup.Ctx, msgCreateModelVersion)
@@ -1795,7 +1839,6 @@ func TestHandler_DeleteModelVersionCertified(t *testing.T) {
 
 	msgDeleteModelVersion := NewMsgDeleteModelVersion(setup.Vendor)
 
-	complianceKeeper := setup.ComplianceKeeper
 	complianceKeeper.On("GetComplianceInfo", mock.Anything, msgDeleteModelVersion.Vid, msgDeleteModelVersion.Pid, msgDeleteModelVersion.SoftwareVersion, mock.Anything).Return(true)
 	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false)
 
@@ -1815,6 +1858,8 @@ func TestHandler_DeleteModelVersionByVendorWithProductIds(t *testing.T) {
 	_, err := setup.Handler(setup.Ctx, msgCreateModel)
 	require.NoError(t, err)
 
+	complianceKeeper := setup.ComplianceKeeper
+	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(false)
 	// add new model version
 	msgCreateModelVersion := NewMsgCreateModelVersion(owner, testconstants.SoftwareVersion)
 	msgCreateModelVersion.Pid = 200
@@ -1832,7 +1877,6 @@ func TestHandler_DeleteModelVersionByVendorWithProductIds(t *testing.T) {
 	msgDeleteModelVersion = NewMsgDeleteModelVersion(owner)
 	msgDeleteModelVersion.Pid = 200
 
-	complianceKeeper := setup.ComplianceKeeper
 	complianceKeeper.On("GetComplianceInfo", mock.Anything, msgDeleteModelVersion.Vid, msgDeleteModelVersion.Pid, msgDeleteModelVersion.SoftwareVersion, mock.Anything).Return(false)
 	complianceKeeper.On("GetComplianceInfo", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(true)
 

--- a/x/model/keeper/msg_server_model.go
+++ b/x/model/keeper/msg_server_model.go
@@ -272,7 +272,8 @@ func (k msgServer) DeleteModel(goCtx context.Context, msg *types.MsgDeleteModel)
 	if found {
 		// check if no model version has certification record
 		for _, softwareVersion := range modelVersions.SoftwareVersions {
-			if k.IsComplianceInfoPresent(ctx, msg.Vid, msg.Pid, softwareVersion) {
+			_, complianceInfoFound := k.GetComplianceInfo(ctx, msg.Vid, msg.Pid, softwareVersion)
+			if complianceInfoFound {
 				return nil, types.NewErrModelDeletionCertified(msg.Vid, msg.Pid, softwareVersion)
 			}
 		}

--- a/x/model/keeper/msg_server_model_version.go
+++ b/x/model/keeper/msg_server_model_version.go
@@ -48,11 +48,11 @@ func (k msgServer) CreateModelVersion(goCtx context.Context, msg *types.MsgCreat
 	complianceInfo, found := k.GetComplianceInfo(ctx, msg.Vid, msg.Pid, msg.SoftwareVersion)
 	if found {
 		if complianceInfo.SoftwareVersionString != msg.SoftwareVersionString {
-			return nil, types.NewErrModelVersionStringDoesNotMatch(msg.Vid, msg.Pid, msg.SoftwareVersion, msg.SoftwareVersionString)
+			return nil, types.NewErrComplianceInfoSoftwareVersionStringDoesNotMatch(msg.Vid, msg.Pid, msg.SoftwareVersion, msg.SoftwareVersionString)
 		}
 
 		if int32(complianceInfo.CDVersionNumber) != msg.CdVersionNumber {
-			return nil, types.NewErrModelVersionCDVersionNumberDoesNotMatch(msg.Vid, msg.Pid, msg.SoftwareVersion, msg.CdVersionNumber)
+			return nil, types.NewErrComplianceInfoCDVersionNumberDoesNotMatch(msg.Vid, msg.Pid, msg.SoftwareVersion, msg.CdVersionNumber)
 		}
 	}
 

--- a/x/model/types/errors.go
+++ b/x/model/types/errors.go
@@ -152,7 +152,7 @@ func NewErrEnhancedSetupFlowTCRevisionInvalidIncrement(newEnhancedSetupFlowTCRev
 		"EnhancedSetupFlowTCRevision %v is not correctly incremented to %v", prevEnhancedSetupFlowTCRevision, newEnhancedSetupFlowTCRevision)
 }
 
-func NewErrModelVersionStringDoesNotMatch(vid interface{}, pid interface{},
+func NewErrComplianceInfoSoftwareVersionStringDoesNotMatch(vid interface{}, pid interface{},
 	softwareVersion interface{}, softwareVersionString interface{},
 ) error {
 	return errors.Wrapf(
@@ -163,7 +163,7 @@ func NewErrModelVersionStringDoesNotMatch(vid interface{}, pid interface{},
 	)
 }
 
-func NewErrModelVersionCDVersionNumberDoesNotMatch(vid interface{}, pid interface{},
+func NewErrComplianceInfoCDVersionNumberDoesNotMatch(vid interface{}, pid interface{},
 	softwareVersion interface{}, cDVersionNumber interface{},
 ) error {
 	return errors.Wrapf(

--- a/x/model/types/errors.go
+++ b/x/model/types/errors.go
@@ -12,23 +12,25 @@ var (
 	ErrFallbackURLRequiresBitmask = errors.Register(ModuleName, 505, "CommissioningFallbackUrl requires DiscoveryCapabilitiesBitmask")
 
 	// Model Version Error Codes.
-	ErrSoftwareVersionStringInvalid       = errors.Register(ModuleName, 511, "software version string invalid")
-	ErrFirmwareInformationInvalid         = errors.Register(ModuleName, 512, "firmware digests invalid")
-	ErrCDVersionNumberInvalid             = errors.Register(ModuleName, 513, "CD version number invalid")
-	ErrOtaURLInvalid                      = errors.Register(ModuleName, 514, "OTA URL invalid")
-	ErrOtaMissingInformation              = errors.Register(ModuleName, 515, "OTA missing information")
-	ErrReleaseNotesURLInvalid             = errors.Register(ModuleName, 516, "release notes URL invalid")
-	ErrModelVersionDoesNotExist           = errors.Register(ModuleName, 517, "model version does not exist")
-	ErrNoModelVersionsExist               = errors.Register(ModuleName, 518, "no model versions exist")
-	ErrModelVersionAlreadyExists          = errors.Register(ModuleName, 519, "model version already exists")
-	ErrOtaURLCannotBeSet                  = errors.Register(ModuleName, 520, "OTA URL cannot be set")
-	ErrMaxSVLessThanMinSV                 = errors.Register(ModuleName, 521, "max software version less than min software version")
-	ErrLsfRevisionIsNotValid              = errors.Register(ModuleName, 522, "LsfRevision should monotonically increase by 1")
-	ErrLsfRevisionIsNotAllowed            = errors.Register(ModuleName, 523, "LsfRevision is not allowed if LsfURL is not present")
-	ErrModelVersionDeletionCertified      = errors.Register(ModuleName, 524, "model version has a compliance record and can not be deleted")
-	ErrModelDeletionCertified             = errors.Register(ModuleName, 525, "model has a model version that has a compliance record and  correcponding model can not be deleted")
-	ErrFieldIsNotBase64Encoded            = errors.Register(ModuleName, 526, "Field is not base64 encoded string")
-	ErrEnhancedSetupFlowTCRevisionInvalid = errors.Register(ModuleName, 527, "enhanced setup flow TC revision invalid")
+	ErrSoftwareVersionStringInvalid                    = errors.Register(ModuleName, 511, "software version string invalid")
+	ErrFirmwareInformationInvalid                      = errors.Register(ModuleName, 512, "firmware digests invalid")
+	ErrCDVersionNumberInvalid                          = errors.Register(ModuleName, 513, "CD version number invalid")
+	ErrOtaURLInvalid                                   = errors.Register(ModuleName, 514, "OTA URL invalid")
+	ErrOtaMissingInformation                           = errors.Register(ModuleName, 515, "OTA missing information")
+	ErrReleaseNotesURLInvalid                          = errors.Register(ModuleName, 516, "release notes URL invalid")
+	ErrModelVersionDoesNotExist                        = errors.Register(ModuleName, 517, "model version does not exist")
+	ErrNoModelVersionsExist                            = errors.Register(ModuleName, 518, "no model versions exist")
+	ErrModelVersionAlreadyExists                       = errors.Register(ModuleName, 519, "model version already exists")
+	ErrOtaURLCannotBeSet                               = errors.Register(ModuleName, 520, "OTA URL cannot be set")
+	ErrMaxSVLessThanMinSV                              = errors.Register(ModuleName, 521, "max software version less than min software version")
+	ErrLsfRevisionIsNotValid                           = errors.Register(ModuleName, 522, "LsfRevision should monotonically increase by 1")
+	ErrLsfRevisionIsNotAllowed                         = errors.Register(ModuleName, 523, "LsfRevision is not allowed if LsfURL is not present")
+	ErrModelVersionDeletionCertified                   = errors.Register(ModuleName, 524, "model version has a compliance record and can not be deleted")
+	ErrModelDeletionCertified                          = errors.Register(ModuleName, 525, "model has a model version that has a compliance record and  correcponding model can not be deleted")
+	ErrFieldIsNotBase64Encoded                         = errors.Register(ModuleName, 526, "Field is not base64 encoded string")
+	ErrEnhancedSetupFlowTCRevisionInvalid              = errors.Register(ModuleName, 527, "enhanced setup flow TC revision invalid")
+	ErrComplianceInfoSoftwareVersionStringDoesNotMatch = errors.Register(ModuleName, 528, "compliance info software version string does not match")
+	ErrComplianceInfoCDVersionNumberDoesNotMatch       = errors.Register(ModuleName, 529, "compliance info CD version number does not match")
 )
 
 func NewErrModelAlreadyExists(vid interface{}, pid interface{}) error {
@@ -148,4 +150,26 @@ func NewErrEnhancedSetupFlowTCDigestIsNotBase64Encoded(enhancedSetupFlowTCDigest
 func NewErrEnhancedSetupFlowTCRevisionInvalidIncrement(newEnhancedSetupFlowTCRevision int32, prevEnhancedSetupFlowTCRevision int32) error {
 	return errors.Wrapf(ErrEnhancedSetupFlowTCRevisionInvalid,
 		"EnhancedSetupFlowTCRevision %v is not correctly incremented to %v", prevEnhancedSetupFlowTCRevision, newEnhancedSetupFlowTCRevision)
+}
+
+func NewErrModelVersionStringDoesNotMatch(vid interface{}, pid interface{},
+	softwareVersion interface{}, softwareVersionString interface{},
+) error {
+	return errors.Wrapf(
+		ErrComplianceInfoSoftwareVersionStringDoesNotMatch,
+		"Compliance Info with vid=%v, pid=%v, softwareVersion=%v present on the ledger does not have"+
+			" matching softwareVersionString=%v",
+		vid, pid, softwareVersion, softwareVersionString,
+	)
+}
+
+func NewErrModelVersionCDVersionNumberDoesNotMatch(vid interface{}, pid interface{},
+	softwareVersion interface{}, cDVersionNumber interface{},
+) error {
+	return errors.Wrapf(
+		ErrComplianceInfoCDVersionNumberDoesNotMatch,
+		"Compliance Info with vid=%v, pid=%v, softwareVersion=%v present on the ledger does not have"+
+			" matching CDVersionNumber=%v",
+		vid, pid, softwareVersion, cDVersionNumber,
+	)
 }


### PR DESCRIPTION
- Enable adding Device Software Compliance Info even Model Version does not exist on the ledger
- Add extra validation  while Adding Model Version - when Compliance Info already exists, check that its software version string and cd version number matches
- Update tests and docs

Closes #706 